### PR TITLE
docs: Fixed command to open multi_keyring.html in example-browser

### DIFF
--- a/modules/example-browser/Readme.md
+++ b/modules/example-browser/Readme.md
@@ -79,7 +79,7 @@ open html/aes_simple.html
 
 ```
 npm run example-multi-keyring
-open html/multi_keyring_simple.html
+open html/multi_keyring.html
 ```
 
 ## License


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* There was a mistake in the filename to open multi_keyring in example-browse. Fixed the issue by changing the command with correct filename. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

