### PR TITLE
fix: eval in portableTimingSafeEqual

### DIFF
--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -86,7 +86,7 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
      * The eval below is commented out
      * because if a browser is using a Content Security Policy with `'unsafe-eval'`
      * it would fail on this eval.
-     * The value in attempting to ensure this function is not optimized,
+     * The value in attempting to ensure that this function is not optimized
      * is not worth the cost of making customers allow `'unsafe-eval'`.
      * If you copy this function for your own use, make sure to educate yourself.
      * Side channel attacks are pernicious and subtle.

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -83,7 +83,7 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
   function portableTimingSafeEqual (a: Uint8Array, b: Uint8Array) {
     /* It is *possible* that a runtime could optimize this constant time function.
      * Adding `eval` could prevent the optimization, but this is no guarantee.
-     * The eval below is commented out,
+     * The eval below is commented out
      * because if a browser is using a Content Security Policy with `'unsafe-eval'`
      * it would fail on this eval.
      * The value in attempting to ensure this function is not optimized,

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -87,7 +87,7 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
      * because if a browser is using a Content Security Policy with `'unsafe-eval'`
      * it would fail on this eval.
      * The value in attempting to ensure this function is not optimized,
-     * is not worth the cost of making customers to alow `'unsafe-eval'`.
+     * is not worth the cost of making customers allow `'unsafe-eval'`.
      * If you copy this function for your own use, make sure to educate yourself.
      * Side channel attacks are pernicious and subtle.
      */

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -92,7 +92,7 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
      * Side channel attacks are pernicious and subtle.
      */
     // eval('') // eslint-disable-line no-eval
-    /* Check for early return (Postcondition) UNTESTED: Size is well-know information.
+    /* Check for early return (Postcondition) UNTESTED: Size is well-know information
      * and does not leak information about contents.
      */
     if (a.byteLength !== b.byteLength) return false

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -82,7 +82,7 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
   /* https://codahale.com/a-lesson-in-timing-attacks/ */
   function portableTimingSafeEqual (a: Uint8Array, b: Uint8Array) {
     /* It is *possible* that a runtime could optimize this constant time function.
-     * Adding `eval` could prevent the optimization, but this is no grantee.
+     * Adding `eval` could prevent the optimization, but this is no guarantee.
      * The eval below is commented out,
      * because if a browser is using a Content Security Policy with `'unsafe-eval'`
      * it would fail on this eval.

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -88,7 +88,8 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
      * it would fail on this eval.
      * The value in attempting to ensure that this function is not optimized
      * is not worth the cost of making customers allow `'unsafe-eval'`.
-     * If you copy this function for your own use, make sure to educate yourself.
+     * If you want to copy this function for your own use,
+     * please review the timing-attack link above.
      * Side channel attacks are pernicious and subtle.
      */
     // eval('') // eslint-disable-line no-eval

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -82,14 +82,19 @@ const timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean = (function () 
   /* https://codahale.com/a-lesson-in-timing-attacks/ */
   function portableTimingSafeEqual (a: Uint8Array, b: Uint8Array) {
     /* It is *possible* that a runtime could optimize this constant time function.
-      * Adding `eval` should prevent the optimization, but this is no grantee.
-      * If you copy this function for your own use, make sure to educate yourself.
-      * Side channel attacks are pernicious and subtle.
-      */
-    eval('') // eslint-disable-line no-eval
+     * Adding `eval` could prevent the optimization, but this is no grantee.
+     * The eval below is commented out,
+     * because if a browser is using a Content Security Policy with `'unsafe-eval'`
+     * it would fail on this eval.
+     * The value in attempting to ensure this function is not optimized,
+     * is not worth the cost of making customers to alow `'unsafe-eval'`.
+     * If you copy this function for your own use, make sure to educate yourself.
+     * Side channel attacks are pernicious and subtle.
+     */
+    // eval('') // eslint-disable-line no-eval
     /* Check for early return (Postcondition) UNTESTED: Size is well-know information.
-      * and does not leak information about contents.
-      */
+     * and does not leak information about contents.
+     */
     if (a.byteLength !== b.byteLength) return false
 
     let diff = 0


### PR DESCRIPTION
`eval` was added to help ensure that `portableTimingSafeEqual`
is not optimized into a non-constant time function.
However, the Content Security Policy `'unsafe-eval'` will flag this.

It is better to remove this and risk such an optimization,
then to force customers to weaken the Content Security Policy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

