### PR TITLE
fix: Import declaration conflicts with local declaration

### DIFF
--- a/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
+++ b/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
@@ -16,7 +16,6 @@
 import {
   WebCryptoMaterialsManager, EncryptionRequest, // eslint-disable-line no-unused-vars
   DecryptionRequest, EncryptionContext, // eslint-disable-line no-unused-vars
-  EncryptionMaterial, DecryptionMaterial, // eslint-disable-line no-unused-vars
   WebCryptoAlgorithmSuite, WebCryptoEncryptionMaterial,
   WebCryptoDecryptionMaterial, SignatureKey, needs, readOnlyProperty,
   VerificationKey, AlgorithmSuiteIdentifier, immutableBaseClass,
@@ -29,8 +28,6 @@ import { fromBase64, toBase64 } from '@aws-sdk/util-base64-browser'
 
 export type WebCryptoEncryptionRequest = EncryptionRequest<WebCryptoAlgorithmSuite>
 export type WebCryptoDecryptionRequest = DecryptionRequest<WebCryptoAlgorithmSuite>
-export type WebCryptoEncryptionMaterial = EncryptionMaterial<WebCryptoAlgorithmSuite>
-export type WebCryptoDecryptionMaterial = DecryptionMaterial<WebCryptoAlgorithmSuite>
 export type WebCryptoGetEncryptionMaterials = GetEncryptionMaterials<WebCryptoAlgorithmSuite>
 export type WebCryptoGetDecryptMaterials = GetDecryptMaterials<WebCryptoAlgorithmSuite>
 

--- a/modules/material-management-node/src/node_cryptographic_materials_manager.ts
+++ b/modules/material-management-node/src/node_cryptographic_materials_manager.ts
@@ -15,7 +15,6 @@
 
 import {
   NodeMaterialsManager, EncryptionRequest, DecryptionRequest, EncryptionContext, // eslint-disable-line no-unused-vars
-  EncryptionMaterial, DecryptionMaterial, // eslint-disable-line no-unused-vars
   NodeAlgorithmSuite, NodeEncryptionMaterial, NodeDecryptionMaterial, SignatureKey,
   needs, VerificationKey, AlgorithmSuiteIdentifier,
   immutableClass, readOnlyProperty, KeyringNode,
@@ -28,8 +27,6 @@ import { createECDH } from 'crypto'
 
 export type NodeEncryptionRequest = EncryptionRequest<NodeAlgorithmSuite>
 export type NodeDecryptionRequest = DecryptionRequest<NodeAlgorithmSuite>
-export type NodeEncryptionMaterial = EncryptionMaterial<NodeAlgorithmSuite>
-export type NodeDecryptionMaterial = DecryptionMaterial<NodeAlgorithmSuite>
 export type NodeGetEncryptionMaterials = GetEncryptionMaterials<NodeAlgorithmSuite>
 export type NodeGetDecryptMaterials = GetDecryptMaterials<NodeAlgorithmSuite>
 


### PR DESCRIPTION
resolves #232

Typescript 3.7 does a better job identifying declaration conflicts
and so identifies the conflict between the type
and the class import of the same name.
e.g. `WebCryptoEncryptionMaterial` is defined as a type and imported.
When #148 was written the reference to the return type
should have gone directly to the needed Material (WebCrypto or Node).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

