### PR TITLE
feat: Support sha256 and sha512 oaep algorithms

### DIFF
--- a/modules/integration-node/src/decrypt_materials_manager_node.ts
+++ b/modules/integration-node/src/decrypt_materials_manager_node.ts
@@ -14,7 +14,6 @@
  */
 
 import {
-  needs,
   MultiKeyringNode,
   KmsKeyringNode,
   RawAesKeyringNode,
@@ -83,17 +82,15 @@ export function rsaKeyring (keyInfo: RsaKeyInfo, key: RSAKey) {
     ? { privateKey: key.material }
     : { publicKey: key.material }
   const padding = rsaPadding(keyInfo)
-  return new RawRsaKeyringNode({ keyName, keyNamespace, rsaKey, padding })
+  const oaepHash = keyInfo['padding-hash']
+  return new RawRsaKeyringNode({ keyName, keyNamespace, rsaKey, padding, oaepHash })
 }
 
 export function rsaPadding (keyInfo: RsaKeyInfo) {
   const paddingAlgorithm = keyInfo['padding-algorithm']
-  const paddingHash = keyInfo['padding-hash']
-
-  if (paddingAlgorithm === 'pkcs1') return constants.RSA_PKCS1_PADDING
-  needs(paddingHash === 'sha1', 'Not supported at this time.')
-
-  return constants.RSA_PKCS1_OAEP_PADDING
+  return paddingAlgorithm === 'pkcs1'
+    ? constants.RSA_PKCS1_PADDING
+    : constants.RSA_PKCS1_OAEP_PADDING
 }
 
 export class NotSupported extends Error {

--- a/modules/raw-rsa-keyring-node/src/index.ts
+++ b/modules/raw-rsa-keyring-node/src/index.ts
@@ -14,3 +14,4 @@
  */
 
 export * from './raw_rsa_keyring_node'
+export * from './oaep_hash_supported'

--- a/modules/raw-rsa-keyring-node/src/oaep_hash_supported.ts
+++ b/modules/raw-rsa-keyring-node/src/oaep_hash_supported.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* oaepHash support was added in Node.js v12.9.1 (https://github.com/nodejs/node/pull/28335)
+ * However, the integration tests need to be able to verify functionality on other versions.
+ * There are no constants to sniff,
+ * and looking at the version would not catch back-ports.
+ * So I simply try the function.
+ * However there is a rub as the test might seem backwards.
+ * Sending an invalid hash to the version that supports oaepHash will throw an error.
+ * But sending an invalid hash to a version that does not support oaepHash will be ignored.
+ */
+
+import {
+  needs
+} from '@aws-crypto/material-management-node'
+
+import {
+  constants,
+  publicEncrypt
+} from 'crypto'
+
+export const oaepHashSupported = (function () {
+  const key = '-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAs7RoNYEPAIws89VV+kra\nrVv/4wbdmUAaAKWgWuxZi5na9GJSmnhCkqyLRm7wPbQY4LCoa5/IMUxkHLsYDPdu\nudY0Qm0GcoxOlvJKHYo4RjF7HyiS34D6dvyO4Gd3aq0mZHoxSGCxW/7hf03wEMzc\niVJXWHXhaI0lD6nrzIEgLrE4L+3V2LeAQjvZsTKd+bYMqeZOL2syiVVIAU8POwAG\nGVBroJoveFm/SUp6lCiN0M2kTeyQA2ax3QTtZSAa8nwrI7U52XOzVmdMicJsy2Pg\nuW98te3MuODdK24yNkHIkYameP/Umf/SJshUJQd5a/TUp3XE+HhOWAumx22tIDlC\nvZS11cuk2fp0WeHUnXaC19N5qWKfvHEKSugzty/z3lGP7ItFhrF2X1qJHeAAsL11\nkjo6Lc48KsE1vKvbnW4VLyB3wdNiVvmUNO29tPXwaR0Q5Gbr3jk3nUzdkEHouHWQ\n41lubOHCCBN3V13mh/MgtNhESHjfmmOnh54ErD9saA1d7CjTf8g2wqmjEqvGSW6N\nq7zhcWR2tp1olflS7oHzul4/I3hnkfL6Kb2xAWWaQKvg3mtsY2OPlzFEP0tR5UcH\nPfp5CeS1Xzg7hN6vRICW6m4l3u2HJFld2akDMm1vnSz8RCbPW7jp7YBxUkWJmypM\ntG7Yv2aGZXGbUtM8o1cZarECAwEAAQ==\n-----END PUBLIC KEY-----'
+
+  const oaepHash = 'i_am_not_valid'
+  try {
+    // @ts-ignore
+    publicEncrypt({ key, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash }, Buffer.from([1, 2, 3, 4]))
+    /* See note above,
+     * only versions that support oaepHash will respond.
+     * So the only way I can get here is if the option was ignored.
+     */
+    return false
+  } catch (ex) {
+    needs(ex.code === 'ERR_OSSL_EVP_INVALID_DIGEST', 'Unexpected error testing oaepHash.')
+    return true
+  }
+})()

--- a/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
+++ b/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
@@ -64,7 +64,7 @@ export type RawRsaKeyringNodeInput = {
   keyName: string
   rsaKey: RsaKey
   padding?: number
-  oaepHash?: 'sha1'|'sha256'|'sha512'
+  oaepHash?: 'sha1'|'sha256'|'sha384'|'sha512'
 }
 
 /* Node supports RSA_OAEP_SHA1_MFG1 by default.

--- a/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
+++ b/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
@@ -32,7 +32,9 @@ import {
   constants,
   publicEncrypt,
   privateDecrypt,
-  randomBytes
+  randomBytes,
+  RsaPublicKey, // eslint-disable-line no-unused-vars
+  RsaPrivateKey // eslint-disable-line no-unused-vars
 } from 'crypto'
 
 import {
@@ -62,6 +64,7 @@ export type RawRsaKeyringNodeInput = {
   keyName: string
   rsaKey: RsaKey
   padding?: number
+  oaepHash?: 'sha1'|'sha256'|'sha512'
 }
 
 /* Node supports RSA_OAEP_SHA1_MFG1 by default.
@@ -78,7 +81,7 @@ export class RawRsaKeyringNode extends KeyringNode {
   constructor (input: RawRsaKeyringNodeInput) {
     super()
 
-    const { rsaKey, keyName, keyNamespace, padding = constants.RSA_PKCS1_OAEP_PADDING } = input
+    const { rsaKey, keyName, keyNamespace, padding = constants.RSA_PKCS1_OAEP_PADDING, oaepHash } = input
     const { publicKey, privateKey } = rsaKey
     /* Precondition: RsaKeyringNode needs either a public or a private key to operate. */
     needs(publicKey || privateKey, 'No Key provided.')
@@ -90,7 +93,7 @@ export class RawRsaKeyringNode extends KeyringNode {
       if (!publicKey) throw new Error('No public key defined in constructor.  Encrypt disabled.')
       const { buffer, byteOffset, byteLength } = unwrapDataKey(material.getUnencryptedDataKey())
       const encryptedDataKey = publicEncrypt(
-        { key: publicKey, padding },
+        { key: publicKey, padding, oaepHash } as RsaPublicKey,
         Buffer.from(buffer, byteOffset, byteLength))
       const providerInfo = this.keyName
       const providerId = this.keyNamespace
@@ -112,7 +115,7 @@ export class RawRsaKeyringNode extends KeyringNode {
       const { buffer, byteOffset, byteLength } = edk.encryptedDataKey
       const encryptedDataKey = Buffer.from(buffer, byteOffset, byteLength)
       const unencryptedDataKey = privateDecrypt(
-        { key: privateKey, padding },
+        { key: privateKey, padding, oaepHash } as RsaPrivateKey,
         encryptedDataKey)
       return material.setUnencryptedDataKey(unencryptedDataKey, trace)
     }

--- a/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
+++ b/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
@@ -67,11 +67,6 @@ export type RawRsaKeyringNodeInput = {
   oaepHash?: 'sha1'|'sha256'|'sha384'|'sha512'
 }
 
-/* Node supports RSA_OAEP_SHA1_MFG1 by default.
- * It does not support RSA_OAEP_SHA256_MFG1 at this time.
- * Passing RSA_PKCS1_OAEP_PADDING implies RSA_OAEP_SHA1_MFG1.
- */
-
 export class RawRsaKeyringNode extends KeyringNode {
   public keyNamespace!: string
   public keyName!: string

--- a/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
+++ b/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
@@ -168,7 +168,7 @@ describe('RawRsaKeyringNode encrypt/decrypt', () => {
     return expect(keyring.onEncrypt(material)).to.rejectedWith(Error)
   })
 
-  xit('Precondition: Private key must be defined to support decrypt.', async () => {
+  it('Precondition: Private key must be defined to support decrypt.', async () => {
     const keyring = new RawRsaKeyringNode({
       rsaKey: { publicKey: publicPem },
       keyName,
@@ -177,7 +177,6 @@ describe('RawRsaKeyringNode encrypt/decrypt', () => {
 
     const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256)
     const material = new NodeDecryptionMaterial(suite, {})
-    await keyring.onDecrypt(material, [encryptedDataKey])
-    return expect(keyring.onDecrypt(material, [encryptedDataKey])).to.rejectedWith(Error)
+    return expect(keyring._unwrapKey(material, encryptedDataKey)).to.rejectedWith(Error)
   })
 })

--- a/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
+++ b/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
@@ -165,10 +165,10 @@ describe('RawRsaKeyringNode encrypt/decrypt', () => {
 
     const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256)
     const material = new NodeEncryptionMaterial(suite, {})
-    expect(keyring.onEncrypt(material)).to.rejectedWith(Error)
+    return expect(keyring.onEncrypt(material)).to.rejectedWith(Error)
   })
 
-  it('Precondition: Private key must be defined to support decrypt.', async () => {
+  xit('Precondition: Private key must be defined to support decrypt.', async () => {
     const keyring = new RawRsaKeyringNode({
       rsaKey: { publicKey: publicPem },
       keyName,
@@ -178,6 +178,6 @@ describe('RawRsaKeyringNode encrypt/decrypt', () => {
     const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256)
     const material = new NodeDecryptionMaterial(suite, {})
     await keyring.onDecrypt(material, [encryptedDataKey])
-    expect(keyring.onDecrypt(material, [encryptedDataKey])).to.rejectedWith(Error)
+    return expect(keyring.onDecrypt(material, [encryptedDataKey])).to.rejectedWith(Error)
   })
 })

--- a/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
+++ b/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
@@ -126,13 +126,15 @@ describe('RawRsaKeyringNode::constructor', () => {
   })
 })
 
-describe('RawRsaKeyringNode encrypt/decrypt', () => {
+const oaepHashOptions: (undefined|'sha1'|'sha256'|'sha512')[] = [undefined, 'sha1', 'sha256', 'sha512']
+oaepHashOptions.forEach(oaepHash => describe(`RawRsaKeyringNode encrypt/decrypt for oaepHash=${oaepHash || 'undefined'}`, () => {
   const keyNamespace = 'keyNamespace'
   const keyName = 'keyName'
   const keyring = new RawRsaKeyringNode({
     rsaKey: { privateKey: privatePem, publicKey: publicPem },
     keyName,
-    keyNamespace
+    keyNamespace,
+    oaepHash
   })
   let encryptedDataKey: EncryptedDataKey
 
@@ -179,4 +181,4 @@ describe('RawRsaKeyringNode encrypt/decrypt', () => {
     const material = new NodeDecryptionMaterial(suite, {})
     return expect(keyring._unwrapKey(material, encryptedDataKey)).to.rejectedWith(Error)
   })
-})
+}))

--- a/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
+++ b/modules/raw-rsa-keyring-node/test/raw_rsa_keyring_node.test.ts
@@ -126,7 +126,7 @@ describe('RawRsaKeyringNode::constructor', () => {
   })
 })
 
-const oaepHashOptions: (undefined|'sha1'|'sha256'|'sha512')[] = [undefined, 'sha1', 'sha256', 'sha512']
+const oaepHashOptions: (undefined|'sha1'|'sha256'|'sha384'|'sha512')[] = [undefined, 'sha1', 'sha256', 'sha384', 'sha512']
 oaepHashOptions.forEach(oaepHash => describe(`RawRsaKeyringNode encrypt/decrypt for oaepHash=${oaepHash || 'undefined'}`, () => {
   const keyNamespace = 'keyNamespace'
   const keyName = 'keyName'


### PR DESCRIPTION
*Issue #, if available:* #198 

*Description of changes:*

AWS CloudFront Field Level Encryption uses the `RSA_OAEP_SHA256_MGF1` suite of algorithms. Because this library's raw RSA code only supports OAEP_SHA1, it can't be used to decrypt CloudFront fields.

Support for oaepHash was added in node's crypto library in node 12.9 (nodejs/node#28335), so it's possible to expose this functionality through this library now.

I've tested this manually against AWS CloudFront with Field Level Encryption set, and it seems to work nicely.

I also spotted some async test warnings, so I've done my best to clean those up. See the individual commits for more detail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [x] Were any files moved? No.

