### PR TITLE
fix: missing dependency in caching-materials-manager-browser

### DIFF
--- a/modules/caching-materials-manager-browser/package.json
+++ b/modules/caching-materials-manager-browser/package.json
@@ -21,6 +21,7 @@
     "@aws-crypto/serialize": "file:../serialize",
     "@aws-crypto/web-crypto-backend": "file:../web-crypto-backend",
     "@aws-sdk/util-base64-browser": "1.0.0-beta.2",
+    "@aws-sdk/util-utf8-browser": "1.0.0-beta.2",
     "tslib": "^1.11.1"
   },
   "sideEffects": false,


### PR DESCRIPTION
Caching materials manager browser is missing `@aws-sdk/util-utf8-browser`.
Everything generally worked because this is installed
by several other modules.
But this was a required dependency for this module in isolation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

