### PR TITLE
fix: nonFramed maximum content length

### DIFF
--- a/modules/serialize/src/decode_body_header.ts
+++ b/modules/serialize/src/decode_body_header.ts
@@ -248,7 +248,7 @@ export function decodeNonFrameBodyHeader(
    * https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/data-format/message-body.md#encrypted-content-length
    */
   needs(
-    Maximum.BYTES_PER_AES_GCM_NONCE >= contentLength,
+    Maximum.BYTES_PER_AES_GCM_NONCE > contentLength,
     'Content length out of bounds.'
   )
   return {

--- a/modules/serialize/src/decode_body_header.ts
+++ b/modules/serialize/src/decode_body_header.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js'
-import { ContentType, SequenceIdentifier } from './identifiers'
+import { ContentType, SequenceIdentifier, Maximum } from './identifiers'
 import {
   HeaderInfo,
   BodyHeader,
@@ -244,6 +244,13 @@ export function decodeNonFrameBodyHeader(
   // This will throw if the number is larger than Number.MAX_SAFE_INTEGER.
   // i.e. a 53 bit number
   const contentLength = contentLengthBN.toNumber()
+  /* Postcondition: Non-framed content length MUST NOT exceed AES-GCM safe limits.
+   * https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/data-format/message-body.md#encrypted-content-length
+   */
+  needs(
+    Maximum.BYTES_PER_AES_GCM_NONCE >= contentLength,
+    'Content length out of bounds.'
+  )
   return {
     sequenceNumber: 1,
     iv,

--- a/modules/serialize/src/identifiers.ts
+++ b/modules/serialize/src/identifiers.ts
@@ -74,6 +74,18 @@ export enum Maximum {
    * this value is set to 2 ** 53 - 1.
    */
   BYTES_PER_MESSAGE = 2 ** 53 - 1,
+  /* Maximum number of bytes for a single AES-GCM "operation."
+   * This is related to the GHASH block size,
+   * and can be thought of as the maximum bytes
+   * that can be encrypted with a single IV.
+   * The AWS Encryption SDK for Javascript
+   * does not support non-framed encrypt
+   * https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/data-format/message-body.md#non-framed-data
+   * So this value is only needed to ensure
+   * that messages submitted for decrypt
+   * are well formed.
+   */
+  BYTES_PER_AES_GCM_NONCE = 2 ** 36 - 32,
   // Maximum number of frames allowed in one message as defined in specification
   FRAME_COUNT = 2 ** 32 - 1,
   // Maximum bytes allowed in a single frame as defined in specification

--- a/modules/serialize/src/identifiers.ts
+++ b/modules/serialize/src/identifiers.ts
@@ -77,7 +77,7 @@ export enum Maximum {
   /* Maximum number of bytes for a single AES-GCM "operation."
    * This is related to the GHASH block size,
    * and can be thought of as the maximum bytes
-   * that can be encrypted with a single IV.
+   * that can be encrypted with a single key/IV pair.
    * The AWS Encryption SDK for Javascript
    * does not support non-framed encrypt
    * https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/data-format/message-body.md#non-framed-data

--- a/modules/serialize/test/decode_body_header.test.ts
+++ b/modules/serialize/test/decode_body_header.test.ts
@@ -502,6 +502,7 @@ describe('decodeNonFrameBodyHeader', () => {
     expect(test.tagLength).to.eql(16)
     expect(test.isFinalFrame).to.eql(true)
     expect(test.contentType).to.eql(ContentType.NO_FRAMING)
+    expect(test.contentLength).to.eql(0)
   })
 
   it('Precondition: The contentType must be NO_FRAMING.', () => {
@@ -560,6 +561,26 @@ describe('decodeNonFrameBodyHeader', () => {
       decodeNonFrameBodyHeader(buffer, headerInfo, buffer.byteLength + 1)
     ).to.throw()
     expect(() => decodeNonFrameBodyHeader(buffer, headerInfo, -1)).to.throw()
+  })
+
+  it('Postcondition: Non-framed content length MUST NOT exceed AES-GCM safe limits.', () => {
+    const headerInfo = {
+      messageHeader: {
+        contentType: ContentType.NO_FRAMING,
+      },
+      algorithmSuite: {
+        ivLength: 12,
+        tagLength: 16,
+      },
+    } as any
+
+    expect(() =>
+      decodeNonFrameBodyHeader(
+        fixtures.invalidNonFrameHeaderContentLengthExcedsLimits(),
+        headerInfo,
+        0
+      )
+    ).to.throw('Content length out of bounds.')
   })
 
   it('ArrayBuffer for a Uint8Array or Buffer may be larger than the Uint8Array or Buffer that it is a view over is.', () => {

--- a/modules/serialize/test/fixtures.ts
+++ b/modules/serialize/test/fixtures.ts
@@ -1338,7 +1338,7 @@ export function invalidNonFrameHeaderContentLengthExcedsLimits() {
     255,
     255,
     255,
-    225,
+    224,
   ])
 }
 

--- a/modules/serialize/test/fixtures.ts
+++ b/modules/serialize/test/fixtures.ts
@@ -1317,6 +1317,31 @@ export function basicNonFrameHeader() {
   ])
 }
 
+export function invalidNonFrameHeaderContentLengthExcedsLimits() {
+  return new Uint8Array([
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    15,
+    255,
+    255,
+    255,
+    225,
+  ])
+}
+
 export function basicEncryptionContext() {
   return new Uint8Array([
     0,


### PR DESCRIPTION
nonFramed messages are encrypted under a single operation.
The maximum number of bytes for a single AES-GCM "operation."
is 2 ** 36 - 32
This is related to the GHASH block size,
and can be thought of as the maximum bytes
that can be encrypted with a single IV.
The AWS Encryption SDK for Javascript
does not support non-framed encrypt
https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/data-format/message-body.md#non-framed-data


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

