### PR TITLE
fix: Better messages when no keyring succeeded to decrypt

### DIFF
--- a/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
+++ b/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
@@ -86,7 +86,11 @@ export class WebCryptoDefaultCryptographicMaterialsManager
      * and that the unencrypted data key is non-NULL.
      * See: cryptographic_materials.ts, `getUnencryptedDataKey`
      */
-    needs(material.hasValidKey(), 'Unencrypted data key is invalid.')
+    needs(
+      material.hasValidKey(),
+      'No keyring generated an unencrypted data key.' +
+        '\nYou may not have access to any wrapping keys.'
+    )
 
     /* Postcondition: The WebCryptoEncryptionMaterial must contain at least 1 EncryptedDataKey. */
     needs(
@@ -113,7 +117,11 @@ export class WebCryptoDefaultCryptographicMaterialsManager
      * that the data key matches the algorithm suite specification
      * and that the unencrypted data key is non-NULL.
      */
-    needs(material.hasValidKey(), 'Unencrypted data key is invalid.')
+    needs(
+      material.hasValidKey(),
+      'No keyring attempted to decrypted any of the encrypted data keys.' +
+        '\nYou may not have access to any wrapping keys.'
+    )
 
     return material
   }

--- a/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
@@ -361,7 +361,7 @@ describe('WebCryptoDefaultCryptographicMaterialsManager', () => {
 
     await expect(
       cmm.getEncryptionMaterials({ encryptionContext })
-    ).to.rejectedWith(Error)
+    ).to.rejectedWith(Error, 'No keyring generated an unencrypted data key.')
   })
 
   it('Postcondition: The WebCryptoEncryptionMaterial must contain at least 1 EncryptedDataKey.', async () => {
@@ -485,6 +485,9 @@ describe('WebCryptoDefaultCryptographicMaterialsManager', () => {
         encryptionContext,
         encryptedDataKeys: [edk],
       })
-    ).to.rejectedWith(Error)
+    ).to.rejectedWith(
+      Error,
+      'No keyring attempted to decrypted any of the encrypted data keys.'
+    )
   })
 })

--- a/modules/material-management-node/src/node_cryptographic_materials_manager.ts
+++ b/modules/material-management-node/src/node_cryptographic_materials_manager.ts
@@ -78,7 +78,11 @@ export class NodeDefaultCryptographicMaterialsManager
      * and that the unencrypted data key is non-NULL.
      * See: cryptographic_materials.ts, `getUnencryptedDataKey`
      */
-    needs(material.getUnencryptedDataKey(), 'Unencrypted data key is invalid.')
+    needs(
+      material.hasValidKey(),
+      'No keyring generated an unencrypted data key.' +
+        '\nYou may not have access to any wrapping keys.'
+    )
 
     /* Postcondition: The NodeEncryptionMaterial must contain at least 1 EncryptedDataKey. */
     needs(
@@ -105,7 +109,11 @@ export class NodeDefaultCryptographicMaterialsManager
      * that the data key matches the algorithm suite specification
      * and that the unencrypted data key is non-NULL.
      */
-    needs(material.getUnencryptedDataKey(), 'Unencrypted data key is invalid.')
+    needs(
+      material.hasValidKey(),
+      'No keyring attempted to decrypted any of the encrypted data keys.' +
+        '\nYou may not have access to any wrapping keys.'
+    )
 
     return material
   }

--- a/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
@@ -228,7 +228,7 @@ describe('NodeDefaultCryptographicMaterialsManager', () => {
 
     await expect(
       cmm.getEncryptionMaterials({ suite, encryptionContext: {} })
-    ).to.rejectedWith(Error)
+    ).to.rejectedWith(Error, 'No keyring generated an unencrypted data key.')
   })
 
   it('Postcondition: The NodeEncryptionMaterial must contain at least 1 EncryptedDataKey.', async () => {
@@ -287,7 +287,10 @@ describe('NodeDefaultCryptographicMaterialsManager', () => {
 
     await expect(
       cmm.decryptMaterials({ suite, encryptedDataKeys, encryptionContext: {} })
-    ).to.rejectedWith(Error)
+    ).to.rejectedWith(
+      Error,
+      'No keyring attempted to decrypted any of the encrypted data keys.'
+    )
   })
 
   it('Return decryption material', async () => {


### PR DESCRIPTION
Related #152 

If no keyrings attempt to decrypt any encrypted data keys,
then the message can not be decrypted.
The code attempted to enforce this,
by retrieving the unencrypted data key in node.

There were two issues here

1. The check ensure the validity of the materials,
itself threw an error.
1. Had this check succeeded, the error message
`'Unencrypted data key is invalid.’` is not incredibly more helpful than
'unencryptedDataKey has not been set'

The error message has been updated,
and the tests have been updated
to verify _this_ error message.

On a related note
https://github.com/awslabs/aws-encryption-sdk-specification/issues/97
starts to explore some additional possibilities.
The fullness of this issue is not only in failure,
but success can also have similar issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

