### PR TITLE
fix: Missing errors in raw keyrings

### DIFF
--- a/modules/raw-keyring/test/raw_keyring_decorators.test.ts
+++ b/modules/raw-keyring/test/raw_keyring_decorators.test.ts
@@ -225,7 +225,7 @@ describe('_onDecrypt', () => {
     expect(filterCalled).to.equal(1)
   })
 
-  it('errors in _unwrapKey should not cause _onDecrypt to throw.', async () => {
+  it('Postcondition: An EDK must provide a valid data key or _unwrapKey must not have raised any errors.', async () => {
     const suite = new NodeAlgorithmSuite(
       AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16
     )
@@ -258,8 +258,10 @@ describe('_onDecrypt', () => {
       _filter,
     } as any
 
-    const test = await testKeyring._onDecrypt(material, [edk])
-    expect(test.hasValidKey()).to.equal(false)
+    await expect(testKeyring._onDecrypt(material, [edk])).to.rejectedWith(
+      Error,
+      'Unable to decrypt data key'
+    )
     expect(unwrapCalled).to.equal(1)
     expect(filterCalled).to.equal(1)
   })


### PR DESCRIPTION
Related #152 

On decrypt, error messages can be passed over.
However, if the keyring attempts to decrypt,
and fails how does anyone know what happend?

This is a similar solution to #212


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

