### PR TITLE
fix: add asserts to `needs`

### DIFF
--- a/modules/material-management/src/needs.ts
+++ b/modules/material-management/src/needs.ts
@@ -16,7 +16,7 @@ export function needs(
   condition: any,
   errorMessage: string,
   Err: ErrorConstructor = Error
-) {
+): asserts condition {
   if (!condition) {
     throw new Err(errorMessage)
   }


### PR DESCRIPTION
TypeScript 3.7 released support for assertion functions,
that support positive assertions
that can be evaluated in TypeScript.

This updates the `needs` function to export this behavior,
so it can be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

