### PR TITLE
chore: add GitHub Actions workflow check for copyright header and fix missing copyright headers

### DIFF
--- a/.github/not-grep.toml
+++ b/.github/not-grep.toml
@@ -1,0 +1,19 @@
+[include]
+# Use "include" rather than "prefix" because
+# some CLI entry point files have shebang lines
+# that need to come first.
+"**/*.ts" = """
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+"""
+"**/package.json" = "\"license\": \"Apache-2.0\""
+"**/*.sh" = """
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+[prefix]
+# Exclude the copies of msrcrypto included in examples packages.
+"**/[!msrcrypto]*.js" = """
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+"""

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -1,0 +1,12 @@
+# This workflow performs static analysis checks.
+name: static analysis
+
+on: ["pull_request", "push"]
+
+jobs:
+  not-grep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: not-grep
+        uses: mattsb42-meta/not-grep@1.0.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/caching-materials-manager-browser/karma.conf.js
+++ b/modules/caching-materials-manager-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/decrypt-browser/karma.conf.js
+++ b/modules/decrypt-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/encrypt-browser/karma.conf.js
+++ b/modules/encrypt-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/encrypt-node/src/encrypt.ts
+++ b/modules/encrypt-node/src/encrypt.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   KeyringNode,
   NodeMaterialsManager,

--- a/modules/example-browser/karma.conf.js
+++ b/modules/example-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const webpack = require('webpack')
 const {defaultProvider} = require('@aws-sdk/credential-provider-node')
 

--- a/modules/example-browser/webpack_configs/aes.webpack.config.js
+++ b/modules/example-browser/webpack_configs/aes.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const path = require('path')
 
 module.exports = {

--- a/modules/example-browser/webpack_configs/caching_cmm.webpack.config.js
+++ b/modules/example-browser/webpack_configs/caching_cmm.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const webpack = require('webpack')
 const path = require('path')
 const {defaultProvider} = require('@aws-sdk/credential-provider-node')

--- a/modules/example-browser/webpack_configs/fallback.webpack.config.js
+++ b/modules/example-browser/webpack_configs/fallback.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const path = require('path')
 
 module.exports = {

--- a/modules/example-browser/webpack_configs/kms.webpack.config.js
+++ b/modules/example-browser/webpack_configs/kms.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const webpack = require('webpack')
 const path = require('path')
 const {defaultProvider} = require('@aws-sdk/credential-provider-node')

--- a/modules/example-browser/webpack_configs/multi_keyring.webpack.config.js
+++ b/modules/example-browser/webpack_configs/multi_keyring.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const webpack = require('webpack')
 const path = require('path')
 const {defaultProvider} = require('@aws-sdk/credential-provider-node')

--- a/modules/example-browser/webpack_configs/rsa.webpack.config.js
+++ b/modules/example-browser/webpack_configs/rsa.webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const path = require('path')
 
 module.exports = {

--- a/modules/integration-browser/karma.conf.js
+++ b/modules/integration-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 const { readFileSync } = require('fs')
 

--- a/modules/integration-browser/webpack.config.js
+++ b/modules/integration-browser/webpack.config.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const path = require('path')
 
 module.exports = {

--- a/modules/kms-keyring-browser/karma.conf.js
+++ b/modules/kms-keyring-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/material-management-browser/karma.conf.js
+++ b/modules/material-management-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/raw-aes-keyring-browser/karma.conf.js
+++ b/modules/raw-aes-keyring-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/raw-rsa-keyring-browser/karma.conf.js
+++ b/modules/raw-rsa-keyring-browser/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/modules/raw-rsa-keyring-node/src/oaep_hash_supported.ts
+++ b/modules/raw-rsa-keyring-node/src/oaep_hash_supported.ts
@@ -1,17 +1,5 @@
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
- * this file except in compliance with the License. A copy of the License is
- * located at
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /* oaepHash support was added in Node.js v12.9.1 (https://github.com/nodejs/node/pull/28335)
  * However, the integration tests need to be able to verify functionality on other versions.

--- a/modules/web-crypto-backend/karma.conf.js
+++ b/modules/web-crypto-backend/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Karma configuration
 
 module.exports = function (config) {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "url": "git@github.com:awslabs/aws-encryption-sdk-javascript.git"
   },
   "author": "aws-crypto-tools-team@amazon.com",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/cache-material": "file:modules/cache-material",
     "@aws-crypto/caching-materials-manager-browser": "file:modules/caching-materials-manager-browser",

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 const compilerOptions = Object.assign({
   'esModuleInterop': true,


### PR DESCRIPTION
*Description of changes:*

This adds a GitHub Actions workflow for static analysis checks. Right now the only one is `not-grep`[1], which we're using to check for copyright headers in all source code files.

Also included are fixes for some files that we missed previously.

Run of workflow visible here[2].

[1] https://github.com/marketplace/actions/not-grep
[2] https://github.com/mattsb42-aws/aws-encryption-sdk-javascript/runs/686987225?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

