### PR TITLE
chore: remove @aws-sdk/util-utf8-universal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -344,6 +344,15 @@
             }
           }
         },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -422,6 +431,11 @@
             "ajv-keywords": "^3.1.0"
           }
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -436,31 +450,15 @@
           }
         },
         "ts-loader": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-          "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
+          "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
           "requires": {
             "chalk": "^2.3.0",
             "enhanced-resolve": "^4.0.0",
             "loader-utils": "^1.0.2",
             "micromatch": "^4.0.0",
             "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
           }
         },
         "ts-node": {
@@ -1408,24 +1406,6 @@
         "tslib": "^1.8.0"
       }
     },
-    "@aws-sdk/is-array-buffer": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-beta.2.tgz",
-      "integrity": "sha512-wIxfDCwhNmN5fZ+mUCIVcGP1s6GqXTfJAbPttfuxQW3oItQMZn2PPGiVuIS3F7CPij+/pQGwuw6T3mMJGnivGw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "@aws-sdk/is-node": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-node/-/is-node-1.0.0-beta.2.tgz",
-      "integrity": "sha512-nU50cBOirjUf72yNhu2SXIa7Ln82YcQLc6MxNcvIp5iTwHMHpkWRn5ilF+W1rt1D/V7r87/niEv9XumZhneJ5A==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.0"
-      }
-    },
     "@aws-sdk/karma-credential-loader": {
       "version": "1.0.0-alpha.6",
       "resolved": "https://registry.npmjs.org/@aws-sdk/karma-credential-loader/-/karma-credential-loader-1.0.0-alpha.6.tgz",
@@ -1458,55 +1438,12 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-beta.2.tgz",
       "integrity": "sha512-zqb1EA9FSGLC/J7FBu6KYz+7EGeNG5sE2QeHGtj4tvFLDSJO6/hluDgQzVW1UsYUitdiBelg8m6xj45eGh2+wg=="
     },
-    "@aws-sdk/util-buffer-from": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-beta.2.tgz",
-      "integrity": "sha512-Mowx4haev/uVCoBYSRpZMtkSqrPP54CrldhFFQsKgbnf1bqRGHBZZZiCoS/8s4twb90G1x6FsUbMzLWXCBuTUA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "^1.0.0-beta.2",
-        "tslib": "^1.8.0"
-      }
-    },
     "@aws-sdk/util-locate-window": {
       "version": "1.0.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-alpha.2.tgz",
       "integrity": "sha512-uMnAjOrjxBBp/aC/AiMkjwI5gq4PCZ1vBkt42333h0QjYZYUPiN43WA6FTo6zGC7HIBWmGk8xSMT2JfwWf5xsQ==",
       "requires": {
         "tslib": "^1.8.0"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-1.0.0-beta.2.tgz",
-      "integrity": "sha512-lrQi1kMauHPSU7E7XLvF9Qim5HyDkh6ey0YsGbcx6SMitQzYxyqKk3Y5xsziYIUKdJvvYtoJTbA3Gcg2uQivag==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "^1.0.0-beta.2",
-        "tslib": "^1.8.0"
-      }
-    },
-    "@aws-sdk/util-utf8-universal": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-universal/-/util-utf8-universal-1.0.0-beta.2.tgz",
-      "integrity": "sha512-bWA10kG/yhp/lDMSuQeDYw/9bAnUSYzU3KTkrP2WGQlHBmePQ547KTzmnmOw/Rf3wsPDavO/V8pH52FPUqKaSA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-node": "^1.0.0-beta.2",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
-        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "@aws-sdk/util-utf8-browser": {
-          "version": "1.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-beta.2.tgz",
-          "integrity": "sha512-71qy8bV0L/wFUDdIyOp7T6iMvHV7T2fldlAlfYinun3uigWcQcTgoo6cqsCuoPlDaDsWGLDpnyCzWASEr2aI0A==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.0"
-          }
-        }
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
   "devDependencies": {
     "@aws-sdk/credential-provider-node": "^1.0.0-alpha.7",
     "@aws-sdk/karma-credential-loader": "^1.0.0-alpha.6",
-    "@aws-sdk/util-utf8-universal": "^1.0.0-alpha.3",
     "@types/bn.js": "^4.11.0",
     "@types/chai": "^4.2.11",
     "@types/chai-as-promised": "^7.1.0",


### PR DESCRIPTION
It was not being used,
and was getting deprecated.

https://github.com/aws/aws-sdk-js-v3/pull/1241
https://github.com/aws/aws-sdk-js-v3/pull/1240?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

