### PR TITLE
fix: Update types for newer typescript versions

### DIFF
--- a/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
+++ b/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
@@ -18,6 +18,8 @@ import {
   KeyringWebCrypto,
   GetEncryptionMaterials,
   GetDecryptMaterials,
+  AwsEsdkJsKeyUsage,
+  AwsEsdkJsCryptoKeyPair,
 } from '@aws-crypto/material-management'
 
 import { ENCODED_SIGNER_KEY } from '@aws-crypto/serialize'
@@ -133,14 +135,15 @@ export class WebCryptoDefaultCryptographicMaterialsManager
 
     const webCryptoAlgorithm = { name: 'ECDSA', namedCurve }
     const extractable = false
-    const usages = ['sign']
+    const usages = ['sign'] as AwsEsdkJsKeyUsage[]
     const format = 'raw'
 
-    const { publicKey, privateKey } = await subtle.generateKey(
+    const { publicKey, privateKey } = (await subtle.generateKey(
       webCryptoAlgorithm,
       extractable,
       usages
-    )
+    )) as AwsEsdkJsCryptoKeyPair
+
     const publicKeyBytes = await subtle.exportKey(format, publicKey)
     const compressPoint = SignatureKey.encodeCompressPoint(
       new Uint8Array(publicKeyBytes),
@@ -178,7 +181,7 @@ export class WebCryptoDefaultCryptographicMaterialsManager
     const subtle = getNonZeroByteBackend(backend)
     const webCryptoAlgorithm = { name: 'ECDSA', namedCurve }
     const extractable = false
-    const usages = ['verify']
+    const usages = ['verify'] as AwsEsdkJsKeyUsage[]
     const format = 'raw'
 
     const publicKeyBytes = VerificationKey.decodeCompressPoint(

--- a/modules/material-management/src/types.ts
+++ b/modules/material-management/src/types.ts
@@ -35,6 +35,11 @@ export interface AwsEsdkJsCryptoKey {
   readonly usages: AwsEsdkJsKeyUsage[]
 }
 
+export interface AwsEsdkJsCryptoKeyPair {
+  readonly publicKey: AwsEsdkJsCryptoKey
+  readonly privateKey: AwsEsdkJsCryptoKey
+}
+
 export type MixedBackendCryptoKey = {
   nonZeroByteCryptoKey: AwsEsdkJsCryptoKey
   zeroByteCryptoKey: AwsEsdkJsCryptoKey


### PR DESCRIPTION
To prepare for type updates, a few more type hints are required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

