### PR TITLE
feat: Add maxHeaderSize

### DIFF
--- a/modules/decrypt-node/src/decrypt.ts
+++ b/modules/decrypt-node/src/decrypt.ts
@@ -5,7 +5,7 @@ import {
   NodeMaterialsManager,
   KeyringNode,
 } from '@aws-crypto/material-management-node'
-import { decryptStream } from './decrypt_stream'
+import { decryptStream, DecryptStreamOptions } from './decrypt_stream'
 
 // @ts-ignore
 import { finished } from 'readable-stream'
@@ -17,17 +17,16 @@ export interface DecryptOutput {
   messageHeader: MessageHeader
 }
 
-export interface DecryptOptions {
+export interface DecryptOptions extends DecryptStreamOptions {
   encoding?: BufferEncoding
-  maxBodySize?: number
 }
 
 export async function decrypt(
   cmm: NodeMaterialsManager | KeyringNode,
   ciphertext: Buffer | Uint8Array | Readable | string | NodeJS.ReadableStream,
-  { encoding, maxBodySize }: DecryptOptions = {}
+  { encoding, ...streamOptions }: DecryptOptions = {}
 ): Promise<DecryptOutput> {
-  const stream = decryptStream(cmm, { maxBodySize })
+  const stream = decryptStream(cmm, streamOptions)
 
   const plaintext: Buffer[] = []
   let messageHeader: MessageHeader | false = false

--- a/modules/decrypt-node/src/decrypt_stream.ts
+++ b/modules/decrypt-node/src/decrypt_stream.ts
@@ -17,11 +17,12 @@ import { pipeline, PassThrough } from 'readable-stream'
 
 export interface DecryptStreamOptions {
   maxBodySize?: number
+  maxHeaderSize?: number
 }
 
 export function decryptStream(
   cmm: KeyringNode | NodeMaterialsManager,
-  { maxBodySize }: DecryptStreamOptions = {}
+  { maxBodySize, maxHeaderSize }: DecryptStreamOptions = {}
 ): Duplex {
   /* If the cmm is a Keyring, wrap it with NodeDefaultCryptographicMaterialsManager. */
   cmm =
@@ -29,7 +30,7 @@ export function decryptStream(
       ? new NodeDefaultCryptographicMaterialsManager(cmm)
       : cmm
 
-  const parseHeaderStream = new ParseHeaderStream(cmm)
+  const parseHeaderStream = new ParseHeaderStream(cmm, { maxHeaderSize })
   const verifyStream = new VerifyStream({ maxBodySize })
   const decipherStream = getDecipherStream()
   const stream = new Duplexify(parseHeaderStream, decipherStream)

--- a/modules/decrypt-node/src/parse_header_stream.ts
+++ b/modules/decrypt-node/src/parse_header_stream.ts
@@ -65,7 +65,9 @@ export class ParseHeaderStream extends PortableTransformWithType {
      * overlap should be avoided.
      * Only "read" the max size.
      */
-    const headerInfo = deserialize.deserializeMessageHeader(headerBuffer.slice(0, maxHeaderRead))
+    const headerInfo = deserialize.deserializeMessageHeader(
+      headerBuffer.slice(0, maxHeaderRead)
+    )
     if (!headerInfo) {
       /* Precondition: If maxHeaderSize was set I can not buffer a header larger than maxHeaderSize.
        * The header can be up to ~12GB

--- a/modules/decrypt-node/test/parse_header_stream.test.ts
+++ b/modules/decrypt-node/test/parse_header_stream.test.ts
@@ -60,11 +60,18 @@ describe.only('ParseHeaderStream', () => {
   })
 
   it('Precondition: If maxHeaderSize was set I can not buffer a header larger than maxHeaderSize.', async () => {
-    const completeHeaderLength = 73
     const data = Buffer.from(
       fixtures.base64CiphertextAlgAes256GcmIv12Tag16HkdfWith4Frames(),
       'base64'
     )
+
+    const headerInfo = deserializeMessageHeader(data)
+    needs(headerInfo, 'No header, test impossible')
+    const completeHeaderLength =
+      headerInfo.rawHeader.byteLength +
+      headerInfo.algorithmSuite.ivLength +
+      headerInfo.algorithmSuite.tagLength / 8
+
     const cmm = new NodeDefaultCryptographicMaterialsManager(
       fixtures.decryptKeyring()
     )

--- a/modules/decrypt-node/test/parse_header_stream.test.ts
+++ b/modules/decrypt-node/test/parse_header_stream.test.ts
@@ -53,6 +53,13 @@ describe('ParseHeaderStream', () => {
       fixtures.decryptKeyring()
     )
 
+    /* Starting from 1
+     * test every maxHeaderSize up to
+     * 1 less than the actual header size.
+     * There is a subtle JS assumption here,
+     * that 0 is false and thus an irrational value
+     * to push into `maxHeaderSize`.
+     */
     for (let i = 1; completeHeaderLength > i; i++) {
       await expect(testStream(cmm, data, { maxHeaderSize: i })).rejectedWith(
         Error,
@@ -60,6 +67,11 @@ describe('ParseHeaderStream', () => {
       )
     }
 
+    /* Picking up from the exact header size
+     * test every maxHeaderSize equal to
+     * or greater than the actual header size
+     * (up to the message size).
+     */
     for (let i = completeHeaderLength; data.byteLength > i; i++) {
       await testStream(cmm, data.slice(0, i), { maxHeaderSize: i })
     }

--- a/modules/decrypt-node/test/parse_header_stream.test.ts
+++ b/modules/decrypt-node/test/parse_header_stream.test.ts
@@ -24,7 +24,10 @@ const { expect } = chai
 
 const toUtf8 = (input: Uint8Array) =>
   Buffer.from(input.buffer, input.byteOffset, input.byteLength).toString('utf8')
-const { deserializeMessageHeader } = deserializeFactory(toUtf8, NodeAlgorithmSuite)  
+const { deserializeMessageHeader } = deserializeFactory(
+  toUtf8,
+  NodeAlgorithmSuite
+)
 
 describe.only('ParseHeaderStream', () => {
   it('Postcondition: A completed header MUST have been processed.', async () => {
@@ -35,8 +38,11 @@ describe.only('ParseHeaderStream', () => {
 
     const headerInfo = deserializeMessageHeader(data)
     needs(headerInfo, 'No header, test impossible')
-    const completeHeaderLength = headerInfo.rawHeader.byteLength + headerInfo.algorithmSuite.ivLength + headerInfo.algorithmSuite.tagLength/8
-    
+    const completeHeaderLength =
+      headerInfo.rawHeader.byteLength +
+      headerInfo.algorithmSuite.ivLength +
+      headerInfo.algorithmSuite.tagLength / 8
+
     const cmm = new NodeDefaultCryptographicMaterialsManager(
       fixtures.decryptKeyring()
     )


### PR DESCRIPTION
Resolves: #388

Add maxHeaderSize feature to control
the maximum size of a header that is allowed.

Processing ESDK messages
of unknown size introduces a risk
of highly-bounded resource consumption
due to variable length fields
in the message format.
This is bad for users
that need to decrypt such messages,
especially for such users
that care about
the memory usage of their systems.

For more details see:
https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/proposals/2020-06-26_decrypt-max-header-size-max-body-size/proposal.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

