### PR TITLE
feat: Verify signature before final frame

### DIFF
--- a/modules/decrypt-browser/src/decrypt.ts
+++ b/modules/decrypt-browser/src/decrypt.ts
@@ -109,6 +109,7 @@ export async function _decrypt(
     const signatureInfo = ciphertext.slice(readPos)
 
     const derSignature = deserializeSignature(signatureInfo)
+    needs(derSignature, 'Invalid signature.')
     const rawSignature = der2raw(derSignature, material.suite)
 
     const isValid = await subtleVerify(rawSignature, data)

--- a/modules/decrypt-node/src/verify_stream.ts
+++ b/modules/decrypt-node/src/verify_stream.ts
@@ -252,7 +252,11 @@ export class VerifyStream extends PortableTransformWithType {
     callback()
   }
 
-  _transformSignature = (chunk: Buffer, _enc: string, callback: Function) => {
+  _transformSignature = (
+    chunk: Buffer,
+    _enc: string,
+    callback: (err?: Error) => void
+  ) => {
     const state = this._verifyState
 
     // EOF is an empty buffer, so I need to handle that kind of end.

--- a/modules/decrypt-node/src/verify_stream.ts
+++ b/modules/decrypt-node/src/verify_stream.ts
@@ -267,7 +267,7 @@ export class VerifyStream extends PortableTransformWithType {
       /* Precondition: Only buffer data if the finalAuthTag has been received. */
       needs(finalAuthTag, 'Malformed state.')
       /* Precondition: Only buffer data if a signature is expected. */
-      needs(signatureInfo && this._verify && !state.signature, 'To much data')
+      needs(signatureInfo && this._verify && !state.signature, 'Too much data')
 
       /* Accumulate the signature here.
        * It is verified in _flush.
@@ -318,7 +318,7 @@ export class VerifyStream extends PortableTransformWithType {
           Buffer.from(buffer, byteOffset, byteLength)
         )
         /* Postcondition: The signature must be valid. */
-        needs(isVerified, 'Invalid Signature')
+        needs(isVerified, 'Invalid signature')
       }
 
       return this.emit('AuthTag', finalAuthTag, callback)

--- a/modules/decrypt-node/test/decrypt.test.ts
+++ b/modules/decrypt-node/test/decrypt.test.ts
@@ -103,7 +103,7 @@ describe('decrypt', () => {
         fixtures.invalidSignatureCiphertextAlgAes256GcmIv12Tag16HkdfSha384EcdsaP384(),
         { encoding: 'base64' }
       )
-    ).to.rejectedWith(Error, 'Invalid Signature')
+    ).to.rejectedWith(Error, 'Invalid signature')
   })
 
   it('can decrypt maxBodySize message with a single final frame.', async () => {

--- a/modules/decrypt-node/test/verify_stream.test.ts
+++ b/modules/decrypt-node/test/verify_stream.test.ts
@@ -179,7 +179,10 @@ describe('VerifyStream', () => {
     // First we make sure that the test vector is well formed
     await testStream(cmm, data)
 
-    const source = new ParseHeaderStream(cmm)
+    const source = new ParseHeaderStream(
+      CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT,
+      cmm
+    )
     const test = new VerifyStream({})
 
     /* This is a little ridiculous.
@@ -192,7 +195,7 @@ describe('VerifyStream', () => {
      */
     setImmediate(() => {
       source.write(data, () => {
-        test._transformSignature(Buffer.alloc(1), 'binary', (e: Error) => {
+        test._transformSignature(Buffer.alloc(1), 'binary', (e?: Error) => {
           test.emit('error', e)
         })
       })

--- a/modules/decrypt-node/test/verify_stream.test.ts
+++ b/modules/decrypt-node/test/verify_stream.test.ts
@@ -163,7 +163,7 @@ describe('VerifyStream', () => {
 
     await expect(testStream(cmm, data, Buffer.alloc(1))).rejectedWith(
       Error,
-      'To much data'
+      'Too much data'
     )
   })
 

--- a/modules/serialize/src/signature_info.ts
+++ b/modules/serialize/src/signature_info.ts
@@ -24,7 +24,9 @@ export function deserializeSignature({
   byteLength,
 }: Uint8Array) {
   /* Precondition: There must be information for a signature. */
-  needs(byteLength && byteLength > 2, 'Invalid Signature')
+  needs(typeof byteLength === 'number', 'Invalid Signature')
+  /* Check for early return (Postcondition): There must be enough bytes for the signatureLength. */
+  if (2 > byteLength) return false
   /* Uint8Array is a view on top of the underlying ArrayBuffer.
    * This means that raw underlying memory stored in the ArrayBuffer
    * may be larger than the Uint8Array.  This is especially true of
@@ -35,6 +37,8 @@ export function deserializeSignature({
   const signatureLength = dataView.getUint16(0, false) // big endian
   /* Precondition: The signature length must be positive. */
   needs(signatureLength > 0, 'Invalid Signature')
+  /* Check for early return (Postcondition): There must be enough bytes for the signature. */
+  if (signatureLength + 2 > byteLength) return false
   /* Precondition: The data must match the serialized length. */
   needs(byteLength === signatureLength + 2, 'Invalid Signature')
   return new Uint8Array(buffer, byteOffset + 2, signatureLength)

--- a/modules/serialize/test/signature_info.test.ts
+++ b/modules/serialize/test/signature_info.test.ts
@@ -37,7 +37,9 @@ describe('deserializeSignature', () => {
   })
 
   it('Precondition: The signature length must be positive.', () => {
-    expect(() => deserializeSignature(new Uint8Array([0, 0]))).to.throw('Invalid Signature')
+    expect(() => deserializeSignature(new Uint8Array([0, 0]))).to.throw(
+      'Invalid Signature'
+    )
   })
 
   it('Precondition: The data must match the serialized length.', () => {

--- a/modules/serialize/test/signature_info.test.ts
+++ b/modules/serialize/test/signature_info.test.ts
@@ -25,20 +25,24 @@ describe('deserializeSignature', () => {
 
   it('Precondition: There must be information for a signature.', () => {
     expect(() => deserializeSignature({} as any)).to.throw()
-    expect(() => deserializeSignature(new Uint8Array())).to.throw()
-    expect(() => deserializeSignature(new Uint8Array(1))).to.throw()
-    expect(() => deserializeSignature(new Uint8Array(2))).to.throw()
+  })
+
+  it('Check for early return (Postcondition): There must be enough bytes for the signatureLength.', () => {
+    expect(deserializeSignature(new Uint8Array())).to.equal(false)
+    expect(deserializeSignature(new Uint8Array(1))).to.equal(false)
+  })
+
+  it('Check for early return (Postcondition): There must be enough bytes for the signature.', () => {
+    expect(deserializeSignature(new Uint8Array([0, 1]))).to.equal(false)
   })
 
   it('Precondition: The signature length must be positive.', () => {
-    const badInfo = fixtures.ecdsaP256SignatureInfo()
-    badInfo[1] = 0
-    expect(() => deserializeSignature(badInfo)).to.throw()
+    expect(() => deserializeSignature(new Uint8Array([0, 0]))).to.throw('Invalid Signature')
   })
 
   it('Precondition: The data must match the serialized length.', () => {
     const badInfo = fixtures.ecdsaP256SignatureInfo()
-    badInfo[1] = badInfo[1] + 1
-    expect(() => deserializeSignature(badInfo)).to.throw()
+    badInfo[1] = badInfo[1] - 1
+    expect(() => deserializeSignature(badInfo)).to.throw('Invalid Signature')
   })
 })


### PR DESCRIPTION
Resolves: #390

Data MUST be authenticated before it is released.
But there is a unique edge case
In the end of signed streams.
If the final frame is sent
but the signature has not been sent
the stream will release the plaintext
because the authTag has been received.
However the signature
has still not been verified.

This could lead to customers processing
data that is not valid
and circumvent one of the values of the signature suites
i.e. someone with decrypt can not forage
a new message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

