### PR TITLE
feat!: Multi keyring generator MUST generate

### DIFF
--- a/modules/material-management/test/multi_keyring.test.ts
+++ b/modules/material-management/test/multi_keyring.test.ts
@@ -176,7 +176,7 @@ describe('MultiKeyring: onEncrypt', () => {
     )
   })
 
-  it('Precondition: A Generator Keyring *must* ensure generated material.', async () => {
+  it('Precondition: A Generator Keyring *must* generated material.', async () => {
     const suite = new NodeAlgorithmSuite(
       AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16
     )
@@ -193,11 +193,11 @@ describe('MultiKeyring: onEncrypt', () => {
 
     await expect(mkeyring.onEncrypt(material)).to.rejectedWith(
       Error,
-      'Generator Keyring has not generated material.'
+      'Generator keyring did not generated material.'
     )
   })
 
-  it('Precondition: Only Keyrings explicitly designated as generators can generate material.', async () => {
+  it('Precondition: Keyrings not designated as generators *must not* generate material.', async () => {
     const suite = new NodeAlgorithmSuite(
       AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16
     )
@@ -212,11 +212,11 @@ describe('MultiKeyring: onEncrypt', () => {
     const material = new NodeEncryptionMaterial(suite, {})
     return expect(mkeyring.onEncrypt(material)).to.rejectedWith(
       Error,
-      'Only Keyrings explicitly designated as generators can generate material.'
+      'No data key provided and no generator defined.'
     )
   })
 
-  it('Generator Keyrings do not *have* to generate material if material already exists', async () => {
+  it('Precondition: Keyrings designated as generators *must* generate material.', async () => {
     const suite = new NodeAlgorithmSuite(
       AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16
     )
@@ -235,7 +235,10 @@ describe('MultiKeyring: onEncrypt', () => {
       {}
     ).setUnencryptedDataKey(new Uint8Array(unencryptedDataKey))
 
-    await mkeyring.onEncrypt(material)
+    return expect(mkeyring.onEncrypt(material)).to.rejectedWith(
+      Error,
+      'Data key already generated.'
+    )
   })
 
   it('If material already exists, you do not need a generator.', async () => {


### PR DESCRIPTION
Resolves: #382

BREAKING CHANGE:

This changes the multi keyring
so that configured generators MUST generate.
This will makes it easy for customers
to build configurations
that are [correct by construction](https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/tenets.md#correct-by-construction).

Before the generator keyring may
or may not generate.
This is especially complicated
for AWS KMS CMKs.
The API call and permissions
for generation are different
from encryption.

This change makes
a given configurations deterministic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

