### PR TITLE
fix!: The AWS Kms keyring use of clientProvider

### DIFF
--- a/modules/kms-keyring/src/kms_keyring.ts
+++ b/modules/kms-keyring/src/kms_keyring.ts
@@ -159,9 +159,15 @@ export function KmsKeyringClass<
           grantTokens
         )
 
-        /* clientProvider may not return a client, in this case there is not an EDK to add */
-        if (kmsEDK)
-          material.addEncryptedDataKey(kmsResponseToEncryptedDataKey(kmsEDK))
+        /* There MUST be a EDK for every KeyId
+         * When a user configures a KMS keyring with IDs
+         * the intent is to be able to independently decrypt
+         * with ANY of these IDs.
+         * See: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/kms-keyring.md#onencrypt-goal
+         */
+        material.addEncryptedDataKey(
+          kmsResponseToEncryptedDataKey(kmsEDK)
+        )
       }
 
       return material

--- a/modules/kms-keyring/src/kms_keyring.ts
+++ b/modules/kms-keyring/src/kms_keyring.ts
@@ -165,9 +165,7 @@ export function KmsKeyringClass<
          * with ANY of these IDs.
          * See: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/kms-keyring.md#onencrypt-goal
          */
-        material.addEncryptedDataKey(
-          kmsResponseToEncryptedDataKey(kmsEDK)
-        )
+        material.addEncryptedDataKey(kmsResponseToEncryptedDataKey(kmsEDK))
       }
 
       return material

--- a/modules/kms-keyring/test/helpers.test.ts
+++ b/modules/kms-keyring/test/helpers.test.ts
@@ -3,7 +3,8 @@
 
 /* eslint-env mocha */
 
-import { expect } from 'chai'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 import {
   generateDataKey,
   encrypt,
@@ -11,6 +12,8 @@ import {
   kmsResponseToEncryptedDataKey,
 } from '../src/helpers'
 import { EncryptedDataKey } from '@aws-crypto/material-management'
+chai.use(chaiAsPromised)
+const { expect } = chai
 
 describe('kmsResponseToEncryptedDataKey', () => {
   it('return an EncryptedDataKey', () => {
@@ -149,7 +152,7 @@ describe('encrypt', () => {
     expect(test.CiphertextBlob).to.deep.equal(CiphertextBlob)
   })
 
-  it('Check for early return (Postcondition): clientProvider did not return a client for encrypt.', async () => {
+  it('Postcondition: There MUST be a client for every KeyId', async () => {
     const KeyId = 'arn:aws:kms:us-east-1:123456789012:alias/example-alias'
     const GrantTokens = ['grantToken']
     const Plaintext = new Uint8Array(5)
@@ -159,14 +162,12 @@ describe('encrypt', () => {
       return false
     }
 
-    const test = await encrypt(
-      clientProvider,
-      Plaintext,
-      KeyId,
-      EncryptionContext,
-      GrantTokens
+    await expect(
+      encrypt(clientProvider, Plaintext, KeyId, EncryptionContext, GrantTokens)
+    ).to.rejectedWith(
+      Error,
+      'No client returned by clientProvider from region:'
     )
-    expect(test).to.equal(false)
   })
 
   it('Postcondition: KMS must return serializable encrypted data key.', async () => {

--- a/modules/kms-keyring/test/kms_keyring.onencrypt.test.ts
+++ b/modules/kms-keyring/test/kms_keyring.onencrypt.test.ts
@@ -240,7 +240,7 @@ describe('KmsKeyring: _onEncrypt', () => {
     expect(kmsEDK.providerInfo).to.equal(generatorKeyId)
   })
 
-  it('clientProvider may not return a client, in this case there is not an EDK to add', async () => {
+  it('clientProvider may not return a client, There MUST be a EDK for every KeyId', async () => {
     const generatorKeyId =
       'arn:aws:kms:us-east-1:123456789012:alias/example-alias'
     const suite = new NodeAlgorithmSuite(
@@ -264,9 +264,8 @@ describe('KmsKeyring: _onEncrypt', () => {
       {}
     ).setUnencryptedDataKey(new Uint8Array(suite.keyLengthBytes))
 
-    const material = await testKeyring.onEncrypt(seedMaterial)
-
-    // only setUnencryptedDataKey on seedMaterial
-    expect(material.encryptedDataKeys).to.have.lengthOf(0)
+    await expect(testKeyring.onEncrypt(seedMaterial)).to.rejectedWith(
+      'No client returned by clientProvider from region:'
+    )
   })
 })


### PR DESCRIPTION
On encrypt if an AWS KMS client can not be obtained
Encrypt should HALT.

There MUST be a client for every KeyId
When a user configures a AWS KMS keyring with IDs
the intent is to be able to independently decrypt
with ANY of these IDs.
See: https://github.com/awslabs/aws-encryption-sdk-specification/blob/master/framework/kms-keyring.md#onencrypt-goal
Without a client it is
impossible to encrypt under the given CMK.

BREAKING CHANGE:

The previous behavior was to
allow the client supplier to modify
the AWS KMS KeyId intent.
This resulted in a successful
encrypt but WITHOUT the filtered KeyIds

See #317 for additional details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

