### PR TITLE
feat: CMC capacity of 0 is a null-cache

### DIFF
--- a/modules/cache-material/test/get_local_cryptographic_materials_cache.test.ts
+++ b/modules/cache-material/test/get_local_cryptographic_materials_cache.test.ts
@@ -148,6 +148,27 @@ describe('getLocalCryptographicMaterialsCache', () => {
     expect(test.response === response).to.equal(true)
     expect(Object.isFrozen(test.response)).to.equal(true)
   })
+
+  it('Precondition: A capacity of 0 is defined as a null-cache.', () => {
+    const {
+      getEncryptionMaterial,
+      getDecryptionMaterial,
+      putEncryptionMaterial,
+      putDecryptionMaterial,
+    } = getLocalCryptographicMaterialsCache(0)
+
+    const encryptionKey = 'some encryption key'
+    const encryptionResponse: any = encryptionMaterial
+
+    putEncryptionMaterial(encryptionKey, encryptionResponse, 1)
+    expect(getEncryptionMaterial(encryptionKey, 1)).to.equal(false)
+
+    const decryptionKey = 'some decryption key'
+    const decryptionResponse: any = decryptionMaterial
+
+    putDecryptionMaterial(decryptionKey, decryptionResponse)
+    expect(getDecryptionMaterial(decryptionKey)).to.equal(false)
+  })
 })
 
 describe('cache eviction', () => {


### PR DESCRIPTION
resolves: #397

An unbounded cache is not cryptographically safe.
A null-cache is useful.

This change makes it very explicit
when customers create an unbounded cache.
And offers a null-cache for testing or debugging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

