### PR TITLE
feat!: Updates to the AWS Encryption SDK.

### DIFF
--- a/modules/client-browser/src/index.ts
+++ b/modules/client-browser/src/index.ts
@@ -16,7 +16,7 @@ import { buildEncrypt } from '@aws-crypto/encrypt-browser'
 import { buildDecrypt } from '@aws-crypto/decrypt-browser'
 
 export function buildClient(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
   return {
     ...buildEncrypt(commitmentPolicy),

--- a/modules/client-node/src/index.ts
+++ b/modules/client-node/src/index.ts
@@ -15,7 +15,7 @@ import { buildEncrypt } from '@aws-crypto/encrypt-node'
 import { buildDecrypt } from '@aws-crypto/decrypt-node'
 
 export function buildClient(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
   return {
     ...buildEncrypt(commitmentPolicy),

--- a/modules/decrypt-browser/src/decrypt.ts
+++ b/modules/decrypt-browser/src/decrypt.ts
@@ -64,7 +64,7 @@ export async function _decrypt(
     .map((i) => (i > 15 ? i.toString(16) : '0' + i.toString(16)))
     .join('')
 
-  /* The parsed header algorithmSuite in _decrypt must be supported by the commitmentPolicy. */
+  /* Precondition: The parsed header algorithmSuite in _decrypt must be supported by the commitmentPolicy. */
   CommitmentPolicySuites.isDecryptEnabled(
     commitmentPolicy,
     algorithmSuite,
@@ -79,7 +79,7 @@ export async function _decrypt(
     encryptedDataKeys,
   })
 
-  /* The material algorithmSuite returned to _decrypt must be supported by the commitmentPolicy. */
+  /* Precondition: The material algorithmSuite returned to _decrypt must be supported by the commitmentPolicy. */
   CommitmentPolicySuites.isDecryptEnabled(
     commitmentPolicy,
     material.suite,

--- a/modules/decrypt-browser/src/decrypt_client.ts
+++ b/modules/decrypt-browser/src/decrypt_client.ts
@@ -15,7 +15,7 @@ type CurryFirst<fn extends (...a: any[]) => any> = fn extends (
   : []
 
 export function buildDecrypt(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): {
   decrypt: (...args: CurryFirst<typeof _decrypt>) => ReturnType<typeof _decrypt>
 } {

--- a/modules/decrypt-browser/src/index.ts
+++ b/modules/decrypt-browser/src/index.ts
@@ -1,11 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CommitmentPolicy } from '@aws-crypto/material-management-browser'
-import { buildDecrypt } from './decrypt_client'
+export { buildDecrypt } from './decrypt_client'
 export { MessageHeader } from '@aws-crypto/serialize'
-/** @deprecated Use `buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-export const { decrypt } = buildDecrypt(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
-)
-export { buildDecrypt }

--- a/modules/decrypt-browser/test/compatibility.test.ts
+++ b/modules/decrypt-browser/test/compatibility.test.ts
@@ -5,7 +5,7 @@
 
 import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { decrypt } from '../src/index'
+import { buildDecrypt } from '../src/index'
 import {
   needs,
   importForWebCryptoDecryptionMaterial,
@@ -15,7 +15,10 @@ import {
   WebCryptoEncryptionMaterial,
 } from '@aws-crypto/material-management-browser'
 import * as fixtures from './fixtures'
-import { MessageFormat } from '@aws-crypto/material-management'
+import {
+  CommitmentPolicy,
+  MessageFormat,
+} from '@aws-crypto/material-management'
 import {
   KmsKeyringBrowser,
   KMS,
@@ -25,6 +28,8 @@ import { fromBase64, toBase64 } from '@aws-sdk/util-base64-browser'
 import { toUtf8 } from '@aws-sdk/util-utf8-browser'
 chai.use(chaiAsPromised)
 const { expect } = chai
+
+const { decrypt } = buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
 
 declare const credentials: {
   accessKeyId: string

--- a/modules/decrypt-node/src/decrypt_client.ts
+++ b/modules/decrypt-node/src/decrypt_client.ts
@@ -13,7 +13,7 @@ type CurryFirst<fn extends (...a: any[]) => any> = fn extends (
   : never
 
 export function buildDecrypt(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): {
   decryptStream: (
     ...args: CurryFirst<typeof _decryptStream>

--- a/modules/decrypt-node/src/index.ts
+++ b/modules/decrypt-node/src/index.ts
@@ -1,21 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CommitmentPolicy } from '@aws-crypto/material-management-node'
-import { buildDecrypt } from './decrypt_client'
+
+export { buildDecrypt } from './decrypt_client'
 export { MessageHeader } from '@aws-crypto/serialize'
-import { deprecate } from 'util'
-const { decrypt: decryptTmp, decryptStream: decryptStreamTmp } = buildDecrypt(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
-)
-/** @deprecated Use `buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-const decrypt = deprecate(
-  decryptTmp,
-  'Use `buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/troubleshooting-migration.html'
-)
-/** @deprecated Use `buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-const decryptStream = deprecate(
-  decryptStreamTmp,
-  'Use `buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/troubleshooting-migration.html'
-)
-export { decrypt, decryptStream }
-export { buildDecrypt }

--- a/modules/decrypt-node/src/parse_header_stream.ts
+++ b/modules/decrypt-node/src/parse_header_stream.ts
@@ -67,7 +67,7 @@ export class ParseHeaderStream extends PortableTransformWithType {
 
     const { messageHeader, algorithmSuite } = headerInfo
     const messageIDStr = Buffer.from(messageHeader.messageId).toString('hex')
-    /* The parsed header algorithmSuite from ParseHeaderStream must be supported by the commitmentPolicy. */
+    /* Precondition: The parsed header algorithmSuite from ParseHeaderStream must be supported by the commitmentPolicy. */
     CommitmentPolicySuites.isDecryptEnabled(
       commitmentPolicy,
       algorithmSuite,
@@ -83,7 +83,7 @@ export class ParseHeaderStream extends PortableTransformWithType {
     materialsManager
       .decryptMaterials({ suite, encryptionContext, encryptedDataKeys })
       .then((material) => {
-        /* The material algorithmSuite returned to ParseHeaderStream must be supported by the commitmentPolicy. */
+        /* Precondition: The material algorithmSuite returned to ParseHeaderStream must be supported by the commitmentPolicy. */
         CommitmentPolicySuites.isDecryptEnabled(
           commitmentPolicy,
           material.suite,

--- a/modules/decrypt-node/test/compatibility.test.ts
+++ b/modules/decrypt-node/test/compatibility.test.ts
@@ -11,13 +11,19 @@ import {
   NodeDecryptionMaterial,
   NodeEncryptionMaterial,
 } from '@aws-crypto/material-management-node'
-import { decrypt } from '../src/index'
+import { buildDecrypt } from '../src/index'
 import * as fixtures from './fixtures'
 chai.use(chaiAsPromised)
 const { expect } = chai
-import { MessageFormat, needs } from '@aws-crypto/material-management'
+import {
+  CommitmentPolicy,
+  MessageFormat,
+  needs,
+} from '@aws-crypto/material-management'
 
 import { KmsKeyringNode } from '@aws-crypto/kms-keyring-node'
+
+const { decrypt } = buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
 
 describe('committing algorithm test', () => {
   fixtures.compatibilityVectors().tests.forEach((test) => {

--- a/modules/decrypt-node/test/decrypt.test.ts
+++ b/modules/decrypt-node/test/decrypt.test.ts
@@ -5,12 +5,16 @@
 
 import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { AlgorithmSuiteIdentifier } from '@aws-crypto/material-management-node'
-import { decrypt } from '../src/index'
+import {
+  AlgorithmSuiteIdentifier,
+  CommitmentPolicy,
+} from '@aws-crypto/material-management-node'
+import { buildDecrypt } from '../src/index'
 import * as fixtures from './fixtures'
 chai.use(chaiAsPromised)
 const { expect } = chai
 import from from 'from2'
+const { decrypt } = buildDecrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
 
 describe('decrypt', () => {
   it('string with encoding', async () => {

--- a/modules/decrypt-node/test/parse_header_stream.test.ts
+++ b/modules/decrypt-node/test/parse_header_stream.test.ts
@@ -10,6 +10,9 @@ import * as stream from 'stream'
 const pipeline = util.promisify(stream.pipeline)
 import { ParseHeaderStream } from '../src/parse_header_stream'
 import {
+  NodeAlgorithmSuite,
+  NodeDecryptionMaterial,
+  AlgorithmSuiteIdentifier,
   NodeDefaultCryptographicMaterialsManager,
   needs,
 } from '@aws-crypto/material-management-node'
@@ -37,40 +40,48 @@ describe('ParseHeaderStream', () => {
     )
   })
 
-  // it('The parsed header algorithmSuite from ParseHeaderStream must be supported by the commitmentPolicy.', async () => {
-  //   const cmm = new NodeDefaultCryptographicMaterialsManager(
-  //     fixtures.decryptKeyring()
-  //   )
-  //   const data = Buffer.from(
-  //     fixtures.base64Ciphertext4BytesWith4KFrameLength(),
-  //     'base64'
-  //   )
+  it('Precondition: The parsed header algorithmSuite from ParseHeaderStream must be supported by the commitmentPolicy.', async () => {
+    const cmm = new NodeDefaultCryptographicMaterialsManager(
+      fixtures.decryptKeyring()
+    )
+    const data = Buffer.from(
+      fixtures.base64Ciphertext4BytesWith4KFrameLength(),
+      'base64'
+    )
 
-  //   await expect(
-  //     testStream(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT, cmm, data)
-  //   ).to.rejectedWith(Error, 'Configuration conflict. Cannot process message with ID')
-  // })
+    await expect(
+      testStream(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT, cmm, data)
+    ).to.rejectedWith(
+      Error,
+      'Configuration conflict. Cannot process message with ID'
+    )
+  })
 
-  // it('The material algorithmSuite returned to ParseHeaderStream must be supported by the commitmentPolicy.', async () => {
-  //   let called_decryptMaterials = false
-  //   const cmm = {
-  //     async decryptMaterials() {
-  //       called_decryptMaterials = true
-  //       const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384)
-  //       return new NodeDecryptionMaterial(suite, {})
-  //     }
-  //   } as any
-  //   const data = Buffer.from(
-  //     fixtures.compatibilityVectors().tests[0].ciphertext,
-  //     'base64'
-  //   )
+  it('Precondition: The material algorithmSuite returned to ParseHeaderStream must be supported by the commitmentPolicy.', async () => {
+    let called_decryptMaterials = false
+    const cmm = {
+      async decryptMaterials() {
+        called_decryptMaterials = true
+        const suite = new NodeAlgorithmSuite(
+          AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+        )
+        return new NodeDecryptionMaterial(suite, {})
+      },
+    } as any
+    const data = Buffer.from(
+      fixtures.compatibilityVectors().tests[0].ciphertext,
+      'base64'
+    )
 
-  //   await expect(
-  //     testStream(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT, cmm, data)
-  //   ).to.rejectedWith(Error, 'Configuration conflict. Cannot process message with ID')
+    await expect(
+      testStream(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT, cmm, data)
+    ).to.rejectedWith(
+      Error,
+      'Configuration conflict. Cannot process message with ID'
+    )
 
-  //   expect(called_decryptMaterials).to.equal(true)
-  // })
+    expect(called_decryptMaterials).to.equal(true)
+  })
 
   it('Postcondition: A completed header MUST have been processed.', async () => {
     const completeHeaderLength = 73

--- a/modules/encrypt-browser/src/encrypt_client.ts
+++ b/modules/encrypt-browser/src/encrypt_client.ts
@@ -15,7 +15,7 @@ type CurryFirst<fn extends (...a: any[]) => any> = fn extends (
   : []
 
 export function buildEncrypt(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): {
   encrypt: (...args: CurryFirst<typeof _encrypt>) => ReturnType<typeof _encrypt>
 } {

--- a/modules/encrypt-browser/src/index.ts
+++ b/modules/encrypt-browser/src/index.ts
@@ -1,13 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CommitmentPolicy } from '@aws-crypto/material-management-browser'
-import { buildEncrypt } from './encrypt_client'
+export { buildEncrypt } from './encrypt_client'
 export { MessageHeader } from '@aws-crypto/serialize'
-
-/** @deprecated Use `buildEncrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-export const { encrypt } = buildEncrypt(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
-)
-
-export { buildEncrypt }

--- a/modules/encrypt-browser/test/encrypt.test.ts
+++ b/modules/encrypt-browser/test/encrypt.test.ts
@@ -21,9 +21,10 @@ import {
   decodeBodyHeader,
   deserializeSignature,
 } from '@aws-crypto/serialize'
-import { encrypt } from '../src/index'
+import { buildEncrypt } from '../src/index'
 import { _encrypt } from '../src/encrypt'
 import { toUtf8, fromUtf8 } from '@aws-sdk/util-utf8-browser'
+const { encrypt } = buildEncrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
 
 chai.use(chaiAsPromised)
 const { expect } = chai

--- a/modules/encrypt-node/src/encrypt_client.ts
+++ b/modules/encrypt-node/src/encrypt_client.ts
@@ -13,7 +13,7 @@ type CurryFirst<fn extends (...a: any[]) => any> = fn extends (
   : []
 
 export function buildEncrypt(
-  commitmentPolicy: CommitmentPolicy
+  commitmentPolicy: CommitmentPolicy = CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 ): {
   encryptStream: (
     ...args: CurryFirst<typeof _encryptStream>

--- a/modules/encrypt-node/src/index.ts
+++ b/modules/encrypt-node/src/index.ts
@@ -1,24 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CommitmentPolicy } from '@aws-crypto/material-management-node'
-import { buildEncrypt } from './encrypt_client'
+export { buildEncrypt } from './encrypt_client'
 export { MessageHeader } from '@aws-crypto/serialize'
-
-import { deprecate } from 'util'
-const { encrypt: encryptTmp, encryptStream: encryptStreamTmp } = buildEncrypt(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
-)
-/** @deprecated Use `buildEncrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-const encrypt = deprecate(
-  encryptTmp,
-  'Use `buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/troubleshooting-migration.html'
-)
-/** @deprecated Use `buildEncrypt(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. */
-const encryptStream = deprecate(
-  encryptStreamTmp,
-  'Use `buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)` for migration. See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/troubleshooting-migration.html'
-)
-export { encrypt, encryptStream }
-
-export { buildEncrypt }

--- a/modules/encrypt-node/test/encrypt.test.ts
+++ b/modules/encrypt-node/test/encrypt.test.ts
@@ -21,12 +21,15 @@ import {
   deserializeSignature,
   MessageHeader,
 } from '@aws-crypto/serialize'
-import { encrypt, encryptStream } from '../src/index'
+import { buildEncrypt } from '../src/index'
 import { _encrypt } from '../src/encrypt'
 import from from 'from2'
 // @ts-ignore
 import { finished } from 'readable-stream'
 import { randomBytes } from 'crypto'
+const { encrypt, encryptStream } = buildEncrypt(
+  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+)
 
 chai.use(chaiAsPromised)
 const { expect } = chai

--- a/modules/example-browser/html/disable_commitment.html
+++ b/modules/example-browser/html/disable_commitment.html
@@ -1,0 +1,16 @@
+
+<!DOCTYPE>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Client Side KMS Encryption Test</title>
+    <script src="../build/disable_commitment_bundle.js"></script>
+  </head>
+  <body>
+    <script>
+      // This is exported via the webpack library setting
+      test.disableCommitmentTest()
+    </script>
+  </body>
+</html>

--- a/modules/example-browser/package.json
+++ b/modules/example-browser/package.json
@@ -15,7 +15,8 @@
     "example-kms": "webpack -d --config webpack_configs/kms.webpack.config.js",
     "example-multi-keyring": "webpack -d --config webpack_configs/multi_keyring.webpack.config.js",
     "example-caching-cmm": "webpack -d --config webpack_configs/caching_cmm.webpack.config.js",
-    "example-fallback": "webpack -d --config webpack_configs/fallback.webpack.config.js"
+    "example-fallback": "webpack -d --config webpack_configs/fallback.webpack.config.js",
+    "example-disable-commitment": "webpack -d --config webpack_configs/disable_commitment.webpack.config.js"
   },
   "author": {
     "name": "AWS Crypto Tools Team",

--- a/modules/example-browser/src/aes_simple.ts
+++ b/modules/example-browser/src/aes_simple.ts
@@ -15,8 +15,16 @@ import {
 } from '@aws-crypto/client-browser'
 import { toBase64 } from '@aws-sdk/util-base64-browser'
 
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
 
 /* This is done to facilitate testing. */

--- a/modules/example-browser/src/caching_cmm.ts
+++ b/modules/example-browser/src/caching_cmm.ts
@@ -15,9 +15,19 @@ import {
   getLocalCryptographicMaterialsCache,
 } from '@aws-crypto/client-browser'
 import { toBase64 } from '@aws-sdk/util-base64-browser'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
+
 /* This is injected by webpack.
  * The webpack.DefinePlugin or @aws-sdk/karma-credential-loader will replace the values when bundling.
  * The credential values are pulled from @aws-sdk/credential-provider-node

--- a/modules/example-browser/src/fallback.ts
+++ b/modules/example-browser/src/fallback.ts
@@ -17,6 +17,12 @@ import {
 } from '@aws-crypto/client-browser'
 import { toBase64 } from '@aws-sdk/util-base64-browser'
 
+/* This builds the client with the FORBID_ENCRYPT_ALLOW_DECRYPT commitment policy.
+ * This is because the current version of `msrcrypto`
+ * does not support `HKDF`.
+ * The default commitment policy is `REQUIRE_ENCRYPT_REQUIRE_DECRYPT`
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
   CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
 )

--- a/modules/example-browser/src/kms_simple.ts
+++ b/modules/example-browser/src/kms_simple.ts
@@ -13,9 +13,19 @@ import {
   CommitmentPolicy,
 } from '@aws-crypto/client-browser'
 import { toBase64 } from '@aws-sdk/util-base64-browser'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
+
 /* This is injected by webpack.
  * The webpack.DefinePlugin will replace the values when bundling.
  * The credential values are pulled from @aws-sdk/credential-provider-node

--- a/modules/example-browser/src/rsa_simple.ts
+++ b/modules/example-browser/src/rsa_simple.ts
@@ -13,9 +13,19 @@ import {
   CommitmentPolicy,
 } from '@aws-crypto/client-browser'
 import { toBase64 } from '@aws-sdk/util-base64-browser'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
+
 /* This is done to facilitate testing. */
 export async function testRSA() {
   /* JWK for the RSA Keys to use.

--- a/modules/example-browser/test/index.test.ts
+++ b/modules/example-browser/test/index.test.ts
@@ -10,6 +10,7 @@ import { testKmsSimpleExample } from '../src/kms_simple'
 import { testMultiKeyringExample } from '../src/multi_keyring'
 import { testRSA } from '../src/rsa_simple'
 import { testFallback } from '../src/fallback'
+import { testDisableCommitmentTestExample } from '../src/disable_commitment'
 
 describe('test', () => {
   it('testAES', async () => {
@@ -39,6 +40,11 @@ describe('test', () => {
 
   it('testFallback', async () => {
     const { plainText, plaintext } = await testFallback()
+    expect(plainText).to.deep.equal(plaintext)
+  })
+
+  it('testDisableCommitmentTestExample', async () => {
+    const { plainText, plaintext } = await testDisableCommitmentTestExample()
     expect(plainText).to.deep.equal(plaintext)
   })
 })

--- a/modules/example-browser/webpack_configs/disable_commitment.webpack.config.js
+++ b/modules/example-browser/webpack_configs/disable_commitment.webpack.config.js
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const webpack = require('webpack')
+const path = require('path')
+const {defaultProvider} = require('@aws-sdk/credential-provider-node')
+
+module.exports = (async () => ({
+  entry: './src/disable_commitment.ts',
+  // devtool: 'inline-source-map',
+  module: {
+    rules: [
+      {
+        test: /disable_commitment.ts$/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.module.json'
+            }
+          }
+        ],
+        include: /disable_commitment.ts/,
+        exclude: [/node_modules/]
+      }
+    ]
+  },
+  resolve: {
+    extensions: [ '.tsx', '.ts', '.js' ]
+  },
+  output: {
+    filename: 'disable_commitment_bundle.js',
+    path: path.resolve(__dirname, '..', 'build'),
+    library: 'test',
+    libraryTarget: 'var'
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      credentials: JSON.stringify(await defaultProvider()())
+    })
+  ],
+  node: {
+    util: 'empty'
+  }
+}))()

--- a/modules/example-node/src/aes_simple.ts
+++ b/modules/example-node/src/aes_simple.ts
@@ -8,8 +8,17 @@ import {
   RawAesWrappingSuiteIdentifier,
 } from '@aws-crypto/client-node'
 import { randomBytes } from 'crypto'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
 
 /**

--- a/modules/example-node/src/caching_cmm.ts
+++ b/modules/example-node/src/caching_cmm.ts
@@ -8,9 +8,19 @@ import {
   NodeCachingMaterialsManager,
   getLocalCryptographicMaterialsCache,
 } from '@aws-crypto/client-node'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
+
 export async function cachingCMMNodeSimpleTest() {
   /* A KMS CMK is required to generate the data key.
    * You need kms:GenerateDataKey permission on the CMK in generatorKeyId.

--- a/modules/example-node/src/kms_filtered_discovery.ts
+++ b/modules/example-node/src/kms_filtered_discovery.ts
@@ -7,7 +7,19 @@ import {
   buildClient,
   CommitmentPolicy,
 } from '@aws-crypto/client-node'
-const { decrypt } = buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
+const { decrypt } = buildClient(
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+)
+
 export async function kmsFilteredDiscoveryTest(
   ciphertext: string | Buffer,
   accountID: string,

--- a/modules/example-node/src/kms_regional_discovery.ts
+++ b/modules/example-node/src/kms_regional_discovery.ts
@@ -9,7 +9,19 @@ import {
   buildClient,
   CommitmentPolicy,
 } from '@aws-crypto/client-node'
-const { decrypt } = buildClient(CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
+const { decrypt } = buildClient(
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+)
+
 export async function kmsRegionalDiscoveryLimitTest(
   ciphertext: string | Buffer
 ) {

--- a/modules/example-node/src/kms_simple.ts
+++ b/modules/example-node/src/kms_simple.ts
@@ -6,9 +6,18 @@ import {
   buildClient,
   CommitmentPolicy,
 } from '@aws-crypto/client-node'
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
+
 export async function kmsSimpleTest() {
   /* A KMS CMK is required to generate the data key.
    * You need kms:GenerateDataKey permission on the CMK in generatorKeyId.

--- a/modules/example-node/src/kms_stream.ts
+++ b/modules/example-node/src/kms_stream.ts
@@ -7,8 +7,17 @@ import {
   CommitmentPolicy,
   MessageHeader,
 } from '@aws-crypto/client-node'
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
 const { encryptStream, decryptStream } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
 
 import { finished } from 'stream'

--- a/modules/example-node/src/rsa_simple.ts
+++ b/modules/example-node/src/rsa_simple.ts
@@ -6,12 +6,21 @@ import {
   buildClient,
   CommitmentPolicy,
 } from '@aws-crypto/client-node'
-const { encrypt, decrypt } = buildClient(
-  CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
-)
 import { generateKeyPair } from 'crypto'
 import { promisify } from 'util'
 const generateKeyPairAsync = promisify(generateKeyPair)
+
+/* This builds the client with the REQUIRE_ENCRYPT_REQUIRE_DECRYPT commitment policy,
+ * which enforces that this client only encrypts using committing algorithm suites
+ * and enforces that this client
+ * will only decrypt encrypted messages
+ * that were created with a committing algorithm suite.
+ * This is the default commitment policy
+ * if you build the client with `buildClient()`.
+ */
+const { encrypt, decrypt } = buildClient(
+  CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+)
 
 /**
  * This function is an example of using the RsaKeyringNode

--- a/modules/example-node/test/index.test.ts
+++ b/modules/example-node/test/index.test.ts
@@ -10,6 +10,7 @@ import { kmsStreamTest } from '../src/kms_stream'
 import { aesTest } from '../src/aes_simple'
 import { multiKeyringTest } from '../src/multi_keyring'
 import { cachingCMMNodeSimpleTest } from '../src/caching_cmm'
+import { disableCommitmentTest } from '../src/disable_commitment'
 import { readFileSync } from 'fs'
 
 describe('test', () => {
@@ -46,6 +47,12 @@ describe('test', () => {
 
   it('caching CMM node', async () => {
     const { cleartext, plaintext } = await cachingCMMNodeSimpleTest()
+
+    expect(plaintext.toString()).to.equal(cleartext)
+  })
+
+  it('disableCommitmentTest', async () => {
+    const { cleartext, plaintext } = await disableCommitmentTest()
 
     expect(plaintext.toString()).to.equal(cleartext)
   })

--- a/modules/kms-keyring-browser/src/kms_keyring_browser.ts
+++ b/modules/kms-keyring-browser/src/kms_keyring_browser.ts
@@ -25,7 +25,7 @@ import {
 import { KMS } from 'aws-sdk'
 
 const getKmsClient = getClient(KMS, {
-  customUserAgent: 'AwsEncryptionSdkJavascriptBrowser/1.7.0',
+  customUserAgent: 'AwsEncryptionSdkJavascriptBrowser/2.0.0',
 })
 const cacheKmsClients = cacheClients(getKmsClient)
 

--- a/modules/kms-keyring-node/src/kms_keyring_node.ts
+++ b/modules/kms-keyring-node/src/kms_keyring_node.ts
@@ -19,7 +19,7 @@ import {
 } from '@aws-crypto/material-management-node'
 import { KMS } from 'aws-sdk'
 const getKmsClient = getClient(KMS, {
-  customUserAgent: 'AwsEncryptionSdkJavascriptNodejs/1.7.0',
+  customUserAgent: 'AwsEncryptionSdkJavascriptNodejs/2.0.0',
 })
 const cacheKmsClients = cacheClients(getKmsClient)
 

--- a/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
+++ b/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
@@ -20,7 +20,6 @@ import {
   AwsEsdkJsKeyUsage,
   AwsEsdkJsCryptoKeyPair,
   CommitmentPolicySuites,
-  AlgorithmSuiteIdentifier,
 } from '@aws-crypto/material-management'
 
 import { ENCODED_SIGNER_KEY } from '@aws-crypto/serialize'
@@ -64,10 +63,7 @@ export class WebCryptoDefaultCryptographicMaterialsManager
     suite =
       suite ||
       new WebCryptoAlgorithmSuite(
-        commitmentPolicy
-          ? CommitmentPolicySuites[commitmentPolicy].defaultAlgorithmSuite
-          : /** @deprecate remove fallback default. */
-            AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+        CommitmentPolicySuites[commitmentPolicy].defaultAlgorithmSuite
       )
 
     /* Precondition: WebCryptoDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.

--- a/modules/material-management-node/src/node_cryptographic_materials_manager.ts
+++ b/modules/material-management-node/src/node_cryptographic_materials_manager.ts
@@ -18,7 +18,6 @@ import {
   GetEncryptionMaterials,
   GetDecryptMaterials,
   CommitmentPolicySuites,
-  AlgorithmSuiteIdentifier,
 } from '@aws-crypto/material-management'
 
 import { ENCODED_SIGNER_KEY } from '@aws-crypto/serialize'
@@ -54,10 +53,7 @@ export class NodeDefaultCryptographicMaterialsManager
     suite =
       suite ||
       new NodeAlgorithmSuite(
-        commitmentPolicy
-          ? CommitmentPolicySuites[commitmentPolicy].defaultAlgorithmSuite
-          : /** @deprecate remove fallback default. */
-            AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+        CommitmentPolicySuites[commitmentPolicy].defaultAlgorithmSuite
       )
 
     /* Precondition: NodeDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.

--- a/modules/material-management/src/algorithm_suites.ts
+++ b/modules/material-management/src/algorithm_suites.ts
@@ -38,8 +38,8 @@ Object.freeze(AlgorithmSuiteIdentifier)
 
 export enum CommitmentPolicy {
   'FORBID_ENCRYPT_ALLOW_DECRYPT' = 'FORBID_ENCRYPT_ALLOW_DECRYPT',
-  // 'REQUIRE_ENCRYPT_ALLOW_DECRYPT' = 'REQUIRE_ENCRYPT_ALLOW_DECRYPT',
-  // 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT' = 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT',
+  'REQUIRE_ENCRYPT_ALLOW_DECRYPT' = 'REQUIRE_ENCRYPT_ALLOW_DECRYPT',
+  'REQUIRE_ENCRYPT_REQUIRE_DECRYPT' = 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT',
 }
 Object.freeze(CommitmentPolicy)
 
@@ -168,18 +168,18 @@ export const CommitmentPolicySuites = Object.freeze({
     defaultAlgorithmSuite:
       NonCommittingAlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
   }),
-  // [CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT]: Object.freeze({
-  //   encryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
-  //   decryptEnabledSuites: AlgorithmSuiteIdentifier,
-  //   defaultAlgorithmSuite:
-  //     CommittingAlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
-  // }),
-  // [CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT]: Object.freeze({
-  //   encryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
-  //   decryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
-  //   defaultAlgorithmSuite:
-  //     CommittingAlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
-  // }),
+  [CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT]: Object.freeze({
+    encryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
+    decryptEnabledSuites: AlgorithmSuiteIdentifier,
+    defaultAlgorithmSuite:
+      CommittingAlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
+  }),
+  [CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT]: Object.freeze({
+    encryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
+    decryptEnabledSuites: CommittingAlgorithmSuiteIdentifier,
+    defaultAlgorithmSuite:
+      CommittingAlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
+  }),
 })
 
 export type AlgorithmSuiteName = keyof typeof AlgorithmSuiteIdentifier

--- a/modules/material-management/src/types.ts
+++ b/modules/material-management/src/types.ts
@@ -51,7 +51,7 @@ export interface EncryptionRequest<
 > {
   readonly suite?: S
   readonly encryptionContext: EncryptionContext
-  readonly commitmentPolicy?: CommitmentPolicy
+  readonly commitmentPolicy: CommitmentPolicy
   readonly plaintextLength?: number
 }
 

--- a/modules/serialize/src/deserialize_header_v1.ts
+++ b/modules/serialize/src/deserialize_header_v1.ts
@@ -164,10 +164,6 @@ export function deserializeHeaderV1Factory<Suite extends AlgorithmSuite>({
       headerLength,
       rawHeader,
       algorithmSuite,
-      /** @deprecated use headerAuth */
-      headerIv,
-      /** @deprecated use headerAuth */
-      headerAuthTag,
       headerAuth: {
         headerIv,
         headerAuthTag,

--- a/modules/serialize/src/deserialize_header_v2.ts
+++ b/modules/serialize/src/deserialize_header_v2.ts
@@ -195,10 +195,6 @@ export function deserializeHeaderV2Factory<Suite extends AlgorithmSuite>({
       headerLength,
       rawHeader,
       algorithmSuite,
-      /** @deprecated use headerAuth */
-      headerIv,
-      /** @deprecated use headerAuth */
-      headerAuthTag,
       headerAuth: {
         headerIv,
         headerAuthTag,

--- a/modules/serialize/src/types.ts
+++ b/modules/serialize/src/types.ts
@@ -89,10 +89,6 @@ export type HeaderInfo = {
   headerLength: number
   rawHeader: Uint8Array
   algorithmSuite: AlgorithmSuite
-  /** @deprecated use headerAuth */
-  headerIv: Uint8Array
-  /** @deprecated use headerAuth */
-  headerAuthTag: Uint8Array
   headerAuth: HeaderAuth
 }
 


### PR DESCRIPTION
This change includes fixes for issues that were reported by Thai Duong from Google's Security team, and
for issues that were identified by AWS Cryptography.

BREAKING CHANGE: AWS KMS KeyIDs must be specified explicitly or Discovery mode explicitly chosen.
Key committing suites are now default. CommitmentPolicy requires commitment by default.

See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/migration.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

