### PR TITLE
chore: Update CI to run multiple versions of Node.js

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,18 +1,9 @@
 version: 0.2
 
-env:
-    variables:
-        NODE_OPTIONS: "--max-old-space-size=4096"
-
-phases:
-    install:
-        runtime-versions:
-            nodejs: 10
-        commands:
-            - npm ci --unsafe-perm
-            - npm run build
-    build:
-        commands:
-            - npm test
-            - npm run test_conditions
-            - npm run verdaccio
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: nodejs10
+      buildspec: codebuild/nodejs10.yml
+    - identifier: nodejs12
+      buildspec: codebuild/nodejs12.yml

--- a/codebuild/nodejs10.yml
+++ b/codebuild/nodejs10.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+env:
+    variables:
+        NODE_OPTIONS: "--max-old-space-size=4096"
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 10
+        commands:
+            - npm ci --unsafe-perm
+            - npm run build
+    build:
+        commands:
+            - npm test
+            - npm run test_conditions
+            - npm run verdaccio

--- a/codebuild/nodejs12.yml
+++ b/codebuild/nodejs12.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+env:
+    variables:
+        NODE_OPTIONS: "--max-old-space-size=4096"
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 12
+        commands:
+            - npm ci --unsafe-perm
+            - npm run build
+    build:
+        commands:
+            - npm test
+            - npm run test_conditions
+            - npm run verdaccio


### PR DESCRIPTION
Update buildspec to batch build
to run multiple Node.js runtime versions

* Node.js 10
* Node.js 12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

