### PR TITLE
fix: better dependency injection

### DIFF
--- a/modules/web-crypto-backend/src/backend-factory.ts
+++ b/modules/web-crypto-backend/src/backend-factory.ts
@@ -7,7 +7,7 @@ import {
   supportsSubtleCrypto,
   supportsZeroByteGCM,
 } from '@aws-crypto/supports-web-crypto'
-import { synchronousRandomValues as randomValues } from './synchronous_random_values'
+import { generateSynchronousRandomValues } from './synchronous_random_values'
 import promisifyMsSubtleCrypto from './promisify-ms-crypto'
 
 type MaybeSubtleCrypto = SubtleCrypto | false
@@ -26,6 +26,7 @@ export type MixedSupportWebCryptoBackend = {
 
 export function webCryptoBackendFactory(window: Window) {
   const fallbackRequiredPromise = windowRequiresFallback(window)
+  const randomValues = generateSynchronousRandomValues(window)
   let webCryptoFallbackPromise: Promise<SubtleCrypto> | false = false
 
   return { getWebCryptoBackend, configureFallback }

--- a/modules/web-crypto-backend/test/backend-factory.test.ts
+++ b/modules/web-crypto-backend/test/backend-factory.test.ts
@@ -5,7 +5,6 @@
 
 import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import sinon from 'sinon'
 // import 'mocha'
 import {
   pluckSubtleCrypto,
@@ -14,7 +13,6 @@ import {
   getNonZeroByteBackend,
   getZeroByteSubtle,
 } from '../src/backend-factory'
-import * as browserWindow from '@aws-sdk/util-locate-window'
 
 import * as fixtures from './fixtures'
 chai.use(chaiAsPromised)
@@ -55,11 +53,6 @@ describe('windowRequiresFallback', () => {
 describe('webCryptoBackendFactory', () => {
   describe('configureFallback', () => {
     it('returns a valid and configured fallback.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowNoWebCrypto)
-
       const { configureFallback } = webCryptoBackendFactory(
         fixtures.fakeWindowNoWebCrypto
       )
@@ -67,35 +60,21 @@ describe('webCryptoBackendFactory', () => {
         fixtures.subtleFallbackSupportsZeroByteGCM
       )
 
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
       expect(test === fixtures.subtleFallbackSupportsZeroByteGCM).to.equal(true)
     })
 
     it('Precondition: If a fallback is not required, do not configure one.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoSupportsZeroByteGCM)
-
       const { configureFallback } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoSupportsZeroByteGCM
       )
       const test = await configureFallback(
         fixtures.subtleFallbackSupportsZeroByteGCM
       )
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
 
       expect(test).to.equal(undefined)
     })
 
     it('Precondition: Can not reconfigure fallback.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoOnlyRandomSource)
-
       const { configureFallback } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoOnlyRandomSource
       )
@@ -104,17 +83,9 @@ describe('webCryptoBackendFactory', () => {
       await expect(
         configureFallback(fixtures.subtleFallbackSupportsZeroByteGCM)
       ).to.rejectedWith(Error)
-
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
 
     it('Precondition: Fallback must look like it supports the required operations.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoOnlyRandomSource)
-
       const { configureFallback } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoOnlyRandomSource
       )
@@ -122,17 +93,9 @@ describe('webCryptoBackendFactory', () => {
       await expect(
         configureFallback(fixtures.subtleFallbackNoWebCrypto)
       ).to.rejectedWith(Error)
-
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
 
     it('Postcondition: The fallback must specifically support ZeroByteGCM.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoOnlyRandomSource)
-
       const { configureFallback } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoOnlyRandomSource
       )
@@ -140,25 +103,15 @@ describe('webCryptoBackendFactory', () => {
       await expect(
         configureFallback(fixtures.subtleFallbackZeroByteEncryptFail)
       ).to.rejectedWith(Error)
-
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
   })
 
   describe('getWebCryptoBackend', () => {
     it('getWebCryptoBackend returns subtle and randomValues', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoSupportsZeroByteGCM)
-
       const { getWebCryptoBackend } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoSupportsZeroByteGCM
       )
       const test = await getWebCryptoBackend()
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
 
       expect(test)
         .to.have.property('subtle')
@@ -169,54 +122,27 @@ describe('webCryptoBackendFactory', () => {
     })
 
     it('Precondition: Access to a secure random source is required.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowNoWebCrypto)
-
       const { getWebCryptoBackend } = webCryptoBackendFactory(
         fixtures.fakeWindowNoWebCrypto
       )
       await expect(getWebCryptoBackend()).to.rejectedWith(Error)
-
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
 
     it('Postcondition: If no SubtleCrypto exists, a fallback must configured.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoOnlyRandomSource)
-
       const { getWebCryptoBackend } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoOnlyRandomSource
       )
       await expect(getWebCryptoBackend()).to.rejectedWith(Error)
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
 
     it('Postcondition: If a a subtle backend exists and a fallback is required, one must be configured.', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoZeroByteEncryptFail)
-
       const { getWebCryptoBackend } = webCryptoBackendFactory(
         fixtures.fakeWindowWebCryptoZeroByteEncryptFail
       )
       await expect(getWebCryptoBackend()).to.rejectedWith(Error)
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
     })
 
     it('getWebCryptoBackend returns configured fallback subtle and randomValues', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoOnlyRandomSource)
-
       const {
         getWebCryptoBackend,
         configureFallback,
@@ -226,8 +152,6 @@ describe('webCryptoBackendFactory', () => {
       // I _also_ test its ability to await the configuration.
       configureFallback(fixtures.subtleFallbackSupportsZeroByteGCM) // eslint-disable-line @typescript-eslint/no-floating-promises
       const test = await getWebCryptoBackend()
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
 
       expect(test)
         .to.have.property('subtle')
@@ -236,11 +160,6 @@ describe('webCryptoBackendFactory', () => {
     })
 
     it('getWebCryptoBackend returns MixedSupportWebCryptoBackend', async () => {
-      const { locateWindow } = browserWindow
-      sinon
-        .stub(browserWindow, 'locateWindow')
-        .returns(fixtures.fakeWindowWebCryptoZeroByteEncryptFail)
-
       const {
         getWebCryptoBackend,
         configureFallback,
@@ -252,8 +171,6 @@ describe('webCryptoBackendFactory', () => {
       // I _also_ test its ability to await the configuration.
       configureFallback(fixtures.subtleFallbackSupportsZeroByteGCM) // eslint-disable-line @typescript-eslint/no-floating-promises
       const test = await getWebCryptoBackend()
-      // @ts-ignore
-      browserWindow.locateWindow = locateWindow
 
       expect(test)
         .to.have.property('nonZeroByteSubtle')

--- a/modules/web-crypto-backend/test/synchronous_random_values.test.ts
+++ b/modules/web-crypto-backend/test/synchronous_random_values.test.ts
@@ -4,9 +4,8 @@
 /* eslint-env mocha */
 
 import { expect } from 'chai'
+import { generateSynchronousRandomValues } from '../src/synchronous_random_values'
 import { synchronousRandomValues } from '../src/index'
-import sinon from 'sinon'
-import * as browserWindow from '@aws-sdk/util-locate-window'
 import * as fixtures from './fixtures'
 
 describe('synchronousRandomValues', () => {
@@ -17,18 +16,14 @@ describe('synchronousRandomValues', () => {
   })
 
   it('should return msCrypto random values', () => {
-    const { locateWindow } = browserWindow
-    sinon
-      .stub(browserWindow, 'locateWindow')
-      .returns(fixtures.fakeWindowIE11OnComplete)
+    const synchronousRandomValues = generateSynchronousRandomValues(
+      fixtures.fakeWindowIE11OnComplete
+    )
 
     const test = synchronousRandomValues(5)
     expect(test).to.be.instanceOf(Uint8Array)
     expect(test).lengthOf(5)
     // The random is a stub, so I know the value
     expect(test).to.deep.equal(new Uint8Array(5).fill(1))
-
-    // @ts-ignore
-    browserWindow.locateWindow = locateWindow
   })
 })

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "nyc": "^15.1.0",
     "prettier": "^2.0.4",
     "rimraf": "^3.0.2",
-    "sinon": "^9.0.2",
     "source-map-support": "^0.5.19",
     "ts-loader": "^8.0.6",
     "ts-node": "^8.10.2",


### PR DESCRIPTION
Sinon is nice, but can not support native ES6 modules.
Because these modules are immutable on import.
Since the backen-factory and the synchronousRandomValues
function both share the same `window` object,
this can be trivially accomplished.
The other advantage is that the test are _much_ simpler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

