### PR TITLE
fix: webpack dev mode flags in example-browser

### DIFF
--- a/modules/example-browser/package.json
+++ b/modules/example-browser/package.json
@@ -10,13 +10,13 @@
     "karma": "karma start karma.conf.js",
     "test": "npm run lint && npm run coverage",
     "coverage": "npm run karma && nyc report --exclude-after-remap false -t .karma_output --check-coverage",
-    "example-rsa": "webpack -d --config webpack_configs/rsa.webpack.config.js",
-    "example-aes": "webpack -d --config webpack_configs/aes.webpack.config.js",
-    "example-kms": "webpack -d --config webpack_configs/kms.webpack.config.js",
-    "example-multi-keyring": "webpack -d --config webpack_configs/multi_keyring.webpack.config.js",
-    "example-caching-cmm": "webpack -d --config webpack_configs/caching_cmm.webpack.config.js",
-    "example-fallback": "webpack -d --config webpack_configs/fallback.webpack.config.js",
-    "example-disable-commitment": "webpack -d --config webpack_configs/disable_commitment.webpack.config.js"
+    "example-rsa": "webpack --mode development --config webpack_configs/rsa.webpack.config.js",
+    "example-aes": "webpack --mode development --config webpack_configs/aes.webpack.config.js",
+    "example-kms": "webpack --mode development --config webpack_configs/kms.webpack.config.js",
+    "example-multi-keyring": "webpack --mode development --config webpack_configs/multi_keyring.webpack.config.js",
+    "example-caching-cmm": "webpack --mode development --config webpack_configs/caching_cmm.webpack.config.js",
+    "example-fallback": "webpack --mode development --config webpack_configs/fallback.webpack.config.js",
+    "example-disable-commitment": "webpack --mode development --config webpack_configs/disable_commitment.webpack.config.js"
   },
   "author": {
     "name": "AWS Crypto Tools Team",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

