### PR TITLE
fix: decoded encryption context is frozen

### DIFF
--- a/modules/serialize/src/decode_encryption_context.ts
+++ b/modules/serialize/src/decode_encryption_context.ts
@@ -23,11 +23,13 @@ export function decodeEncryptionContextFactory(
    * Exported for testing.  Used by deserializeMessageHeader to compose a complete solution.
    * @param encodedEncryptionContext Uint8Array
    */
-  function decodeEncryptionContext(encodedEncryptionContext: Uint8Array) {
+  function decodeEncryptionContext(
+    encodedEncryptionContext: Uint8Array
+  ): Readonly<EncryptionContext> {
     const encryptionContext: EncryptionContext = Object.create(null)
     /* Check for early return (Postcondition): The case of 0 length is defined as an empty object. */
     if (!encodedEncryptionContext.byteLength) {
-      return encryptionContext
+      return Object.freeze(encryptionContext)
     }
     /* Uint8Array is a view on top of the underlying ArrayBuffer.
      * This means that raw underlying memory stored in the ArrayBuffer


### PR DESCRIPTION
If the encryption context is empty it should still be frozen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

