### PR TITLE
chore: break up release build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,6 +20,8 @@ batch:
     - identifier: testVectorsNodejsLatest
       buildspec: codebuild/test_vectors/nodejs_latest.yml
       env:
+        variables:
+          PUBLISH_LOCAL: "true"
         image: aws/codebuild/standard:5.0
     - identifier: testVectorsNodejs12
       buildspec: codebuild/test_vectors/nodejs12.yml
@@ -29,3 +31,7 @@ batch:
         image: aws/codebuild/standard:5.0
     - identifier: testVectorsBrowser
       buildspec: codebuild/test_vectors/browser.yml
+      env:
+        variables:
+          PUBLISH_LOCAL: "true"
+        image: aws/codebuild/standard:5.0

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -1,76 +1,65 @@
 version: 0.2
 
-env:
-  variables:
-    NPM_CONFIG_UNSAFE_PERM: true
-    NODE_OPTIONS: "--max-old-space-size=4096"
-    BRANCH: "master"
-    # An explicit version bump
-    VERSION_BUMP: ""
-  secrets-manager:
-     OTP_SECRET_KEY: npm/aws-crypto-tools-ci-bot/2FA:OTP_SECRET_KEY
-     NPM_TOKEN: npm/aws-crypto-tools-ci-bot/2FA:NPM_TOKEN
-  git-credential-helper: yes
-
-phases:
-  install:
-    commands:
-      - npm ci --unsafe-perm
-      # Install `otplib` to extract the OTP from the npm 2FA secret
-      - npm install otplib --no-save
-      - npm run build
-    runtime-versions:
-      nodejs: 12
-  pre_build:
-    commands:
-      - git config --global user.name "aws-crypto-tools-ci-bot"
-      - git config --global user.email "no-reply@noemail.local"
-      - git checkout $BRANCH
-  build:
-    commands:
-      # Pre-check, make sure everything is happy
-      - npm test
-      - npm run test_conditions
-      # Publish to a local verdaccio server and run all tests against it
-      - npm run verdaccio
-      # Generate new version and CHANGELOG entry and push it
-      - npx lerna version --conventional-commits --git-remote origin --yes ${VERSION_BUMP:+$VERSION_BUMP --force-publish}
-      # Log the commit for posterity
-      - git log -n 1
-      # Extract the otp using the secrets environment variables from above.
-      # This will wait for the next token. This is because npm uses
-      # TOTP and the tokens time out after 30 seconds. If the process just
-      # extracted the token then the lifetime for this token
-      # would be very random. This will maximize the amount of time
-      # available on the OTP to publish.
-      - >-
-        OTP=`node -e "
-          auth=require('otplib').authenticator;
-          setTimeout(() =>
-            console.log(auth.generate(process.env.OTP_SECRET_KEY)),
-            auth.timeRemaining() * 1000);
-          "`
-      # npm will only expand env vars inside .npmrc
-      # NOTE the ' this is to keep the env var NPM_TOKEN from expanding!
-      - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-      # Now we publish to npm.
-      # This is going to use the OTP generated above and the NPM_TOKEN
-      # environment variable. This will only publish things that are
-      # missing from npm. It is therefore safe to run repeatedly.
-      - npx lerna publish from-package --yes --otp $OTP
-      # remove after publishing
-      - rm .npmrc
-      # Clear out the verdaccio cache so that we get the latest version
-      # of everything from public npm
-      - rm -rf verdaccio/storage/
-      # Since the cache is empty, and we don't call `verdaccio-publish`
-      # this will run the integrations from the public code in npm
-      - npx run-s verdaccio-publish-*
-
-
-# Batching is technically unnecessary for now since we have just the one
-# buildspec, but leaving it in place makes it easier to extend later on
 batch:
   fast-fail: true 
   build-graph:
-    - identifier: release_to_prod
+
+# Lint and specification compliance
+    - identifier: compliance
+      buildspec: codebuild/compliance.yml
+
+# Unit Tests
+    - identifier: testNodejsLatest
+      buildspec: codebuild/nodejs_latest.yml
+      env:
+        image: aws/codebuild/standard:5.0
+    - identifier: testBrowser
+      buildspec: codebuild/browser.yml
+
+# Integration Tests
+    - identifier: testVectorsNodejsLatest
+      buildspec: codebuild/test_vectors/nodejs_latest.yml
+      env:
+        variables:
+          PUBLISH_LOCAL: "true"
+        image: aws/codebuild/standard:5.0
+    - identifier: testVectorsBrowser
+      buildspec: codebuild/test_vectors/browser.yml
+      env:
+        variables:
+          PUBLISH_LOCAL: "true"
+        image: aws/codebuild/standard:5.0
+
+# Version the project and push git commits and tags
+    - identifier: version
+      depend-on:
+        - compliance
+        - testNodejsLatest
+        - testBrowser
+        - testVectorsNodejsLatest
+        - testVectorsBrowser
+      buildspec: codebuild/release/version.yml
+
+# Publish the release to npm
+    - identifier: publish
+      depend-on:
+        - version
+      buildspec: codebuild/release/publish.yml
+
+# Validate that the published versions are available
+    - identifier: validateNodejs
+      depend-on:
+        - publish
+      buildspec: codebuild/test_vectors/nodejs_latest.yml
+      env:
+        variables:
+          PUBLISH_LOCAL: "false"
+        image: aws/codebuild/standard:5.0
+    - identifier: validateBrowser
+      depend-on:
+        - publish
+      buildspec: codebuild/test_vectors/browser.yml
+      env:
+        variables:
+          PUBLISH_LOCAL: "false"
+        image: aws/codebuild/standard:5.0

--- a/codebuild/release/publish.yml
+++ b/codebuild/release/publish.yml
@@ -1,0 +1,48 @@
+version: 0.2
+
+env:
+  variables:
+    NODE_OPTIONS: "--max-old-space-size=4096"
+    BRANCH: "master"
+  secrets-manager:
+     OTP_SECRET_KEY: npm/aws-crypto-tools-ci-bot/2FA:OTP_SECRET_KEY
+     NPM_TOKEN: npm/aws-crypto-tools-ci-bot/2FA:NPM_TOKEN
+
+phases:
+  install:
+    commands:
+      - npm ci --unsafe-perm
+      # Install `otplib` to extract the OTP from the npm 2FA secret
+      - npm install otplib --no-save
+      - npm run build
+    runtime-versions:
+      nodejs: 12
+  pre_build:
+    commands:
+      - git checkout $BRANCH
+  build:
+    commands:
+      # Extract the otp using the secrets environment variables from above.
+      # This will wait for the next token. This is because npm uses
+      # TOTP and the tokens time out after 30 seconds. If the process just
+      # extracted the token then the lifetime for this token
+      # would be very random. This will maximize the amount of time
+      # available on the OTP to publish.
+      - >-
+        OTP=`node -e "
+          auth=require('otplib').authenticator;
+          setTimeout(() =>
+            console.log(auth.generate(process.env.OTP_SECRET_KEY)),
+            auth.timeRemaining() * 1000);
+          "`
+      # npm will only expand env vars inside .npmrc
+      # NOTE the ' this is to keep the env var NPM_TOKEN from expanding!
+      - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+      # Now we publish to npm.
+      # This is going to use the OTP generated above and the NPM_TOKEN
+      # environment variable. This will only publish things that are
+      # missing from npm. It is therefore safe to run repeatedly.
+      - npx lerna publish from-package --yes --otp $OTP
+      # remove after publishing
+      - rm .npmrc
+

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+env:
+  variables:
+    NODE_OPTIONS: "--max-old-space-size=4096"
+    BRANCH: "master"
+    # An explicit version bump
+    VERSION_BUMP: ""
+  git-credential-helper: yes
+
+phases:
+  install:
+    commands:
+      - npm ci --unsafe-perm
+    runtime-versions:
+      nodejs: 12
+  pre_build:
+    commands:
+      - git config --global user.name "aws-crypto-tools-ci-bot"
+      - git config --global user.email "no-reply@noemail.local"
+      - git checkout $BRANCH
+  build:
+    commands:
+      # Generate new version and CHANGELOG entry and push it
+      - npx lerna version --conventional-commits --git-remote origin --yes ${VERSION_BUMP:+$VERSION_BUMP --force-publish}
+      # Log the commit for posterity
+      - git log -n 1

--- a/codebuild/test_vectors/browser.yml
+++ b/codebuild/test_vectors/browser.yml
@@ -11,9 +11,15 @@ phases:
       nodejs: latest
     commands:
       - npm ci
-      - npm run build
+      - |-
+        if [ "$PUBLISH_LOCAL" = "true" ]; then
+          npm run build
+        fi
   build:
     commands:
-      - npm run verdaccio-publish
+      - |-
+        if [ "$PUBLISH_LOCAL" = "true" ]; then
+          npm run verdaccio-publish
+        fi
       - npm run verdaccio-browser-decrypt
       - npm run verdaccio-browser-encrypt

--- a/codebuild/test_vectors/nodejs_latest.yml
+++ b/codebuild/test_vectors/nodejs_latest.yml
@@ -11,9 +11,15 @@ phases:
       nodejs: latest
     commands:
       - npm ci
-      - npm run build
+      - |-
+        if [ "$PUBLISH_LOCAL" = "true" ]; then
+          npm run build
+        fi
   build:
     commands:
-      - npm run verdaccio-publish
+      - |-
+        if [ "$PUBLISH_LOCAL" = "true" ]; then
+          npm run verdaccio-publish
+        fi
       - npm run verdaccio-node-decrypt
       - npm run verdaccio-node-encrypt


### PR DESCRIPTION
When doing releases having the steps in parts make it easer to follow.
This also makes partial re-try simpler.
Finally, the release now shares the exact tests with CI.
So the release process is better tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

