### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/modules/material-management/src/pem_helpers.ts
+++ b/modules/material-management/src/pem_helpers.ts
@@ -92,7 +92,7 @@ export function chunk64(buff: Buffer) {
   const chunks: string[] = new Array(numChunks)
 
   for (let i = 0, o = 0; i < numChunks; ++i, o += chunkSize) {
-    chunks[i] = str.substr(o, chunkSize)
+    chunks[i] = str.slice(o, o + chunkSize)
   }
 
   return chunks


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

