### PR TITLE
chore: Mark 1.x as End-of-Support 

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,33 @@
+Overview
+========
+This page describes the support policy for the AWS Encryption SDK. We regularly provide the AWS Encryption SDK with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion.
+
+
+Major Version Lifecycle
+========================
+The AWS Encryption SDK follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS Encryption SDK for Javascript. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - End of Support
+      - 
+      - 
+    * - 2.x
+      - General Availability
+      - 
+      - 
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -26,6 +26,10 @@ This table describes the current support status of each major version of the AWS
       - 
       - 
     * - 2.x
+      - Maintenance
+      - End of Support
+      - 2023-03-02
+    * - 3.x
       - General Availability
       - 
       - 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,3 +9,4 @@ batch:
       buildspec: codebuild/nodejs12.yml
       env:
         image: aws/codebuild/standard:5.0
+        compute-type: BUILD_GENERAL1_MEDIUM

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,6 @@ batch:
     - identifier: nodejs10
       buildspec: codebuild/nodejs10.yml
       env:
-        image: aws/codebuild/standard:5.0
         compute-type: BUILD_GENERAL1_MEDIUM
     - identifier: nodejs12
       buildspec: codebuild/nodejs12.yml

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,3 +7,5 @@ batch:
       buildspec: codebuild/nodejs10.yml
     - identifier: nodejs12
       buildspec: codebuild/nodejs12.yml
+      env:
+        image: aws/codebuild/standard:5.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,9 @@ batch:
   build-list:
     - identifier: nodejs10
       buildspec: codebuild/nodejs10.yml
+      env:
+        image: aws/codebuild/standard:5.0
+        compute-type: BUILD_GENERAL1_MEDIUM
     - identifier: nodejs12
       buildspec: codebuild/nodejs12.yml
       env:

--- a/codebuild/nodejs10.yml
+++ b/codebuild/nodejs10.yml
@@ -13,6 +13,7 @@ phases:
             - npm run build
     build:
         commands:
-            - npm test
+            - npm run lint
+            - npm run coverage-node
             - npm run test_conditions
             - npm run verdaccio

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -1,0 +1,32 @@
+version: 0.2
+
+batch:
+  fast-fail: true 
+  build-graph:
+# CI
+    - identifier: nodejs10
+      buildspec: codebuild/nodejs10.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+    - identifier: nodejs12
+      buildspec: codebuild/nodejs12.yml
+      env:
+        image: aws/codebuild/standard:5.0
+        compute-type: BUILD_GENERAL1_MEDIUM
+
+# Version the project and push git commits and tags
+    - identifier: version
+      depend-on:
+        - nodejs10
+        - nodejs12
+      buildspec: codebuild/release/version.yml
+      env:
+        image: aws/codebuild/standard:5.0
+
+# Publish the release to npm
+    - identifier: publish
+      depend-on:
+        - version
+      buildspec: codebuild/release/publish.yml
+      env:
+        image: aws/codebuild/standard:5.0

--- a/codebuild/release/publish.yml
+++ b/codebuild/release/publish.yml
@@ -1,0 +1,48 @@
+version: 0.2
+
+env:
+  variables:
+    NODE_OPTIONS: "--max-old-space-size=4096"
+    BRANCH: "mainline-1.x"
+  secrets-manager:
+     OTP_SECRET_KEY: npm/aws-crypto-tools-ci-bot/2FA:OTP_SECRET_KEY
+     NPM_TOKEN: npm/aws-crypto-tools-ci-bot/2FA:NPM_TOKEN
+
+phases:
+  install:
+    commands:
+      - npm ci --unsafe-perm
+      # Install `otplib` to extract the OTP from the npm 2FA secret
+      - npm install otplib --no-save
+      - npm run build
+    runtime-versions:
+      nodejs: 12
+  pre_build:
+    commands:
+      - git checkout $BRANCH
+  build:
+    commands:
+      # Extract the otp using the secrets environment variables from above.
+      # This will wait for the next token. This is because npm uses
+      # TOTP and the tokens time out after 30 seconds. If the process just
+      # extracted the token then the lifetime for this token
+      # would be very random. This will maximize the amount of time
+      # available on the OTP to publish.
+      - >-
+        OTP=`node -e "
+          auth=require('otplib').authenticator;
+          setTimeout(() =>
+            console.log(auth.generate(process.env.OTP_SECRET_KEY)),
+            auth.timeRemaining() * 1000);
+          "`
+      # npm will only expand env vars inside .npmrc
+      # NOTE the ' this is to keep the env var NPM_TOKEN from expanding!
+      - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+      # Now we publish to npm.
+      # This is going to use the OTP generated above and the NPM_TOKEN
+      # environment variable. This will only publish things that are
+      # missing from npm. It is therefore safe to run repeatedly.
+      - npx lerna publish from-package --yes --otp $OTP
+      # remove after publishing
+      - rm .npmrc
+

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+env:
+  variables:
+    NODE_OPTIONS: "--max-old-space-size=4096"
+    BRANCH: "mainline-1.x"
+    # An explicit version bump
+    VERSION_BUMP: ""
+  git-credential-helper: yes
+
+phases:
+  install:
+    commands:
+      - npm ci --unsafe-perm
+    runtime-versions:
+      nodejs: 12
+  pre_build:
+    commands:
+      - git config --global user.name "aws-crypto-tools-ci-bot"
+      - git config --global user.email "no-reply@noemail.local"
+      - git checkout $BRANCH
+  build:
+    commands:
+      # Generate new version and CHANGELOG entry and push it
+      - npx lerna version --conventional-commits --git-remote origin --yes ${VERSION_BUMP:+$VERSION_BUMP --force-publish}
+      # Log the commit for posterity
+      - git log -n 1

--- a/modules/client-browser/src/index.ts
+++ b/modules/client-browser/src/index.ts
@@ -13,7 +13,7 @@ export * from '@aws-crypto/web-crypto-backend'
 import {
   CommitmentPolicy,
   ClientOptions,
-  EndOfSupportWarning
+  EndOfSupportWarning,
 } from '@aws-crypto/material-management-browser'
 
 import { buildEncrypt } from '@aws-crypto/encrypt-browser'

--- a/modules/client-browser/src/index.ts
+++ b/modules/client-browser/src/index.ts
@@ -13,6 +13,7 @@ export * from '@aws-crypto/web-crypto-backend'
 import {
   CommitmentPolicy,
   ClientOptions,
+  EndOfSupportWarning
 } from '@aws-crypto/material-management-browser'
 
 import { buildEncrypt } from '@aws-crypto/encrypt-browser'
@@ -21,6 +22,7 @@ import { buildDecrypt } from '@aws-crypto/decrypt-browser'
 export function buildClient(
   options: CommitmentPolicy | ClientOptions
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
+  console.log(EndOfSupportWarning.v1)
   return {
     ...buildEncrypt(options),
     ...buildDecrypt(options),

--- a/modules/client-browser/src/index.ts
+++ b/modules/client-browser/src/index.ts
@@ -22,7 +22,7 @@ import { buildDecrypt } from '@aws-crypto/decrypt-browser'
 export function buildClient(
   options: CommitmentPolicy | ClientOptions
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
-  console.log(EndOfSupportWarning.v1)
+  console.warn(EndOfSupportWarning.v1)
   return {
     ...buildEncrypt(options),
     ...buildDecrypt(options),

--- a/modules/client-node/src/index.ts
+++ b/modules/client-node/src/index.ts
@@ -12,6 +12,7 @@ export * from '@aws-crypto/raw-rsa-keyring-node'
 import {
   CommitmentPolicy,
   ClientOptions,
+  EndOfSupportWarning
 } from '@aws-crypto/material-management-node'
 
 import { buildEncrypt } from '@aws-crypto/encrypt-node'
@@ -20,6 +21,7 @@ import { buildDecrypt, DecryptOutput } from '@aws-crypto/decrypt-node'
 export function buildClient(
   options: CommitmentPolicy | ClientOptions
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
+  console.log(EndOfSupportWarning.v1)
   return {
     ...buildEncrypt(options),
     ...buildDecrypt(options),

--- a/modules/client-node/src/index.ts
+++ b/modules/client-node/src/index.ts
@@ -12,7 +12,7 @@ export * from '@aws-crypto/raw-rsa-keyring-node'
 import {
   CommitmentPolicy,
   ClientOptions,
-  EndOfSupportWarning
+  EndOfSupportWarning,
 } from '@aws-crypto/material-management-node'
 
 import { buildEncrypt } from '@aws-crypto/encrypt-node'

--- a/modules/client-node/src/index.ts
+++ b/modules/client-node/src/index.ts
@@ -21,7 +21,7 @@ import { buildDecrypt, DecryptOutput } from '@aws-crypto/decrypt-node'
 export function buildClient(
   options: CommitmentPolicy | ClientOptions
 ): ReturnType<typeof buildEncrypt> & ReturnType<typeof buildDecrypt> {
-  console.log(EndOfSupportWarning.v1)
+  console.warn(EndOfSupportWarning.v1)
   return {
     ...buildEncrypt(options),
     ...buildDecrypt(options),

--- a/modules/material-management-browser/src/index.ts
+++ b/modules/material-management-browser/src/index.ts
@@ -35,4 +35,5 @@ export {
   PolicyOptions,
   MessageFormat,
   ClientOptions,
+  EndOfSupportWarning
 } from '@aws-crypto/material-management'

--- a/modules/material-management-browser/src/index.ts
+++ b/modules/material-management-browser/src/index.ts
@@ -35,5 +35,5 @@ export {
   PolicyOptions,
   MessageFormat,
   ClientOptions,
-  EndOfSupportWarning
+  EndOfSupportWarning,
 } from '@aws-crypto/material-management'

--- a/modules/material-management-node/src/index.ts
+++ b/modules/material-management-node/src/index.ts
@@ -38,5 +38,5 @@ export {
   PolicyOptions,
   MessageFormat,
   ClientOptions,
-  EndOfSupportWarning
+  EndOfSupportWarning,
 } from '@aws-crypto/material-management'

--- a/modules/material-management-node/src/index.ts
+++ b/modules/material-management-node/src/index.ts
@@ -38,4 +38,5 @@ export {
   PolicyOptions,
   MessageFormat,
   ClientOptions,
+  EndOfSupportWarning
 } from '@aws-crypto/material-management'

--- a/modules/material-management/src/index.ts
+++ b/modules/material-management/src/index.ts
@@ -77,3 +77,9 @@ export { needs } from './needs'
 export { cloneMaterial } from './clone_cryptographic_material'
 
 export * from './types'
+
+export enum EndOfSupportWarning {
+  'v1' = "This major version (1.x) of the AWS Encryption SDK for JavaScript has reached End-of-Support.\n" +
+    "It will no longer receive security updates or bug fixes.\n" +
+    "Consider updating to the latest version of the AWS Encryption SDK."
+}

--- a/modules/material-management/src/index.ts
+++ b/modules/material-management/src/index.ts
@@ -79,7 +79,7 @@ export { cloneMaterial } from './clone_cryptographic_material'
 export * from './types'
 
 export enum EndOfSupportWarning {
-  'v1' = "This major version (1.x) of the AWS Encryption SDK for JavaScript has reached End-of-Support.\n" +
-    "It will no longer receive security updates or bug fixes.\n" +
-    "Consider updating to the latest version of the AWS Encryption SDK."
+  'v1' = 'This major version (1.x) of the AWS Encryption SDK for JavaScript has reached End-of-Support.\n' +
+    'It will no longer receive security updates or bug fixes.\n' +
+    'Consider updating to the latest version of the AWS Encryption SDK.',
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "clean": "npm run clear-build-cache && lerna clean",
     "clear-build-cache": "rimraf ./modules/*/build/*",
     "lint": "run-s lint-*",
-    "lint-eslint": "npx eslint modules/**/src/*.ts modules/**/test/**/*.ts",
     "lint-prettier": "prettier -c modules/**/src/*.ts modules/**/test/**/*.ts",
     "build-node": "tsc -b tsconfig.json",
     "build-browser": "tsc -b tsconfig.module.json",


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x as End-of-Support

*Description of changes:*
- Client emits a log warning on creation detailing 1.x is in End-of-Support
- Added the support policy from master

Update Support Policy, marking:
- 1.x as EOS
- 2.x as Maintenance
- 3.x as GA

Back-ported CodeBuild NPM Publish automation.
However, the back port is not as useful as the Master version.
It does not pull the artifacts from NPM and test them after publishing.

To do that, I would need to back-port much [of this PR](https://github.com/aws/aws-encryption-sdk-javascript/pull/645/files#diff-3cf937f50c0e3ea75bb5996259a365af49f2e14274f6bcb2374c9002ebfb5d8f), which deprecates Node10. 

*Squash Commit Message*: `chore: warn 1.x is End-of-Support`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

