### PR TITLE
chore: remove node10 from depends graph

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -13,7 +13,6 @@ batch:
 # Version the project and push git commits and tags
     - identifier: version
       depend-on:
-        - nodejs10
         - nodejs12
       buildspec: codebuild/release/version.yml
       env:


### PR DESCRIPTION
*Description of changes:*
Removing node10 depend step

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

