### PR TITLE
fix(verdaccio): back port verdaccio fixes from master

### DIFF
--- a/modules/integration-browser/karma.conf.js
+++ b/modules/integration-browser/karma.conf.js
@@ -12,6 +12,11 @@ module.exports = function (config) {
   const concurrency = JSON.parse(readFileSync('./fixtures/concurrency.json'))
   config.set({
     basePath: '',
+    client: {
+      jasmine: {
+        timeoutInterval: 10000
+      }
+    },
     frameworks: ['parallel', 'jasmine'],
     files: [
       'fixtures/decrypt_tests.json',

--- a/modules/integration-browser/package.json
+++ b/modules/integration-browser/package.json
@@ -18,6 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/client-browser": "file:../client-browser",
+    "@aws-crypto/integration-vectors": "file:../integration-vectors",
     "@aws-sdk/karma-credential-loader": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",
     "@aws-sdk/util-utf8-browser": "3.1.0",

--- a/modules/integration-node/package.json
+++ b/modules/integration-node/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/client-node": "file:../client-node",
+    "@aws-crypto/integration-vectors": "file:../integration-vectors",  
     "@types/got": "^9.6.9",
     "@types/stream-to-promise": "^2.2.0",
     "@types/yargs": "^15.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "aws-encryption-sdk-javascript",
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -88,7 +89,7 @@
     },
     "modules/cache-material": {
       "name": "@aws-crypto/cache-material",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -116,7 +117,7 @@
     },
     "modules/caching-materials-manager-browser": {
       "name": "@aws-crypto/caching-materials-manager-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/cache-material": "file:../cache-material",
@@ -143,7 +144,7 @@
     },
     "modules/caching-materials-manager-node": {
       "name": "@aws-crypto/caching-materials-manager-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/cache-material": "file:../cache-material",
@@ -153,7 +154,7 @@
     },
     "modules/client-browser": {
       "name": "@aws-crypto/client-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/caching-materials-manager-browser": "file:../caching-materials-manager-browser",
@@ -169,7 +170,7 @@
     },
     "modules/client-node": {
       "name": "@aws-crypto/client-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/caching-materials-manager-node": "file:../caching-materials-manager-node",
@@ -184,7 +185,7 @@
     },
     "modules/decrypt-browser": {
       "name": "@aws-crypto/decrypt-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -195,7 +196,7 @@
     },
     "modules/decrypt-node": {
       "name": "@aws-crypto/decrypt-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -232,7 +233,7 @@
     },
     "modules/encrypt-browser": {
       "name": "@aws-crypto/encrypt-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -244,7 +245,7 @@
     },
     "modules/encrypt-node": {
       "name": "@aws-crypto/encrypt-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -281,7 +282,7 @@
     },
     "modules/example-browser": {
       "name": "@aws-crypto/example-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-browser": "file:../client-browser",
@@ -661,7 +662,7 @@
     },
     "modules/example-node": {
       "name": "@aws-crypto/example-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-node": "file:../client-node",
@@ -670,7 +671,7 @@
     },
     "modules/hkdf-node": {
       "name": "@aws-crypto/hkdf-node",
-      "version": "1.0.3",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -678,10 +679,11 @@
     },
     "modules/integration-browser": {
       "name": "@aws-crypto/integration-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-browser": "file:../client-browser",
+        "@aws-crypto/integration-vectors": "file:../integration-vectors",
         "@aws-sdk/karma-credential-loader": "3.1.0",
         "@aws-sdk/util-base64-browser": "3.1.0",
         "@aws-sdk/util-utf8-browser": "3.1.0",
@@ -864,10 +866,11 @@
     },
     "modules/integration-node": {
       "name": "@aws-crypto/integration-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-node": "file:../client-node",
+        "@aws-crypto/integration-vectors": "file:../integration-vectors",
         "@types/got": "^9.6.9",
         "@types/stream-to-promise": "^2.2.0",
         "@types/yargs": "^15.0.3",
@@ -883,7 +886,8 @@
       }
     },
     "modules/integration-vectors": {
-      "version": "1.0.0",
+      "name": "@aws-crypto/integration-vectors",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-node": "file:../client-node",
@@ -904,7 +908,7 @@
     },
     "modules/kms-keyring": {
       "name": "@aws-crypto/kms-keyring",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -913,7 +917,7 @@
     },
     "modules/kms-keyring-browser": {
       "name": "@aws-crypto/kms-keyring-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/kms-keyring": "file:../kms-keyring",
@@ -925,7 +929,7 @@
     },
     "modules/kms-keyring-node": {
       "name": "@aws-crypto/kms-keyring-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/kms-keyring": "file:../kms-keyring",
@@ -936,7 +940,7 @@
     },
     "modules/material-management": {
       "name": "@aws-crypto/material-management",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1.js": "^5.3.0",
@@ -946,7 +950,7 @@
     },
     "modules/material-management-browser": {
       "name": "@aws-crypto/material-management-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -971,7 +975,7 @@
     },
     "modules/material-management-node": {
       "name": "@aws-crypto/material-management-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/hkdf-node": "file:../hkdf-node",
@@ -982,7 +986,7 @@
     },
     "modules/raw-aes-keyring-browser": {
       "name": "@aws-crypto/raw-aes-keyring-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -996,7 +1000,7 @@
     },
     "modules/raw-aes-keyring-node": {
       "name": "@aws-crypto/raw-aes-keyring-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -1007,7 +1011,7 @@
     },
     "modules/raw-keyring": {
       "name": "@aws-crypto/raw-keyring",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -1017,7 +1021,7 @@
     },
     "modules/raw-rsa-keyring-browser": {
       "name": "@aws-crypto/raw-rsa-keyring-browser",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -1043,7 +1047,7 @@
     },
     "modules/raw-rsa-keyring-node": {
       "name": "@aws-crypto/raw-rsa-keyring-node",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -1053,7 +1057,7 @@
     },
     "modules/serialize": {
       "name": "@aws-crypto/serialize",
-      "version": "2.1.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -1064,7 +1068,7 @@
     },
     "modules/web-crypto-backend": {
       "name": "@aws-crypto/web-crypto-backend",
-      "version": "1.2.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/ie11-detection": "1.0.0",
@@ -27041,6 +27045,7 @@
       "version": "file:modules/integration-browser",
       "requires": {
         "@aws-crypto/client-browser": "file:../client-browser",
+        "@aws-crypto/integration-vectors": "file:../integration-vectors",
         "@aws-sdk/karma-credential-loader": "3.1.0",
         "@aws-sdk/util-base64-browser": "3.1.0",
         "@aws-sdk/util-utf8-browser": "3.1.0",
@@ -27218,6 +27223,7 @@
       "version": "file:modules/integration-node",
       "requires": {
         "@aws-crypto/client-node": "file:../client-node",
+        "@aws-crypto/integration-vectors": "file:../integration-vectors",
         "@types/got": "^9.6.9",
         "@types/stream-to-promise": "^2.2.0",
         "@types/yargs": "^15.0.3",
@@ -40952,6 +40958,7 @@
       "dev": true,
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -40999,6 +41006,7 @@
       "dev": true,
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "integration": "run-s integration-*",
     "verdaccio": "run-s verdaccio-*",
     "verdaccio-publish": "./util/local_verdaccio_publish",
-    "verdaccio-publish-browser-decrypt": "./util/npx_verdaccio @aws-crypto/integration-browser decrypt -v $npm_package_config_localTestVectors --karma -c cpu",
+    "verdaccio-publish-browser-decrypt": "./util/npx_verdaccio @aws-crypto/integration-browser decrypt -v $PWD/$npm_package_config_localTestVectors  --karma -c cpu",
     "verdaccio-publish-browser-encrypt": "./util/npx_verdaccio @aws-crypto/integration-browser encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle --karma -c cpu",
-    "verdaccio-publish-node-decrypt": "./util/npx_verdaccio @aws-crypto/integration-node decrypt -v $npm_package_config_localTestVectors -c cpu",
+    "verdaccio-publish-node-decrypt": "./util/npx_verdaccio @aws-crypto/integration-node decrypt -v $PWD/$npm_package_config_localTestVectors  -c cpu",
     "verdaccio-publish-node-encrypt": "./util/npx_verdaccio @aws-crypto/integration-node encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle -c cpu",
     "test_conditions": "./util/test_conditions"
   },

--- a/util/local_verdaccio_publish
+++ b/util/local_verdaccio_publish
@@ -33,9 +33,9 @@ const args = [
   '--no-git-tag-version',
   '--no-push',
   '--no-git-reset',
-  '--ignore-scripts',
   '--preid', 'ci',
-  '--no-verify-access'
+  '--no-verify-access',
+  '--force-publish'
 ]
 spawn('npx', args, pipeStdIo)
   .on('close', (code) => {
@@ -43,6 +43,7 @@ spawn('npx', args, pipeStdIo)
     // Roll them back
     // Ideally, we would find a way to not have to do this
     execSync('git checkout -- modules/**/package.json')
+    execSync('git checkout -- lerna.json')
 
     // Kill the background verdaccio server
     verdaccio.kill()

--- a/util/npx_verdaccio
+++ b/util/npx_verdaccio
@@ -9,13 +9,8 @@
 // this _can_ be done from bash or shell,
 // but now the portability problems loom large.
 
-const { spawn, execSync } = require('child_process')
+const { spawn } = require('child_process')
 const pipeStdIo = { stdio: [process.stdin, process.stdout, process.stderr] }
-
-// Always clear storage so the latest versions are published
-// I am not worried about _what_ version number is published
-// Only that it is the latest code
-execSync('rm -rf verdaccio/.npx')
 
 // I am assuming that you used `local_verdaccio_publish`
 // But either way,
@@ -29,13 +24,17 @@ const verdaccio = spawn('npx', ['verdaccio', '-c', 'verdaccio/config.yaml'], pip
 
 const args = [
   '--userconfig', 'verdaccio/npmrc',
-  '--ignore-existing',
-  '--cache', 'verdaccio/.npx',
-  // This is **very** important,
+  // In npx v6 ignore-existing let you install the latest version
+  // regardless of what was installed locally.
+  // In npx v7 this is disable and if you need to install anything
+  // then --yes is *required*
+  '--ignore-existing', '--yes',
+  // This is **very** important, (npx ~v6)
   // without this, npx may mask error codes.
   // In testing it was possible to have errors in the npx command
   // but the spawned process here did not exit with a non-zero exit code.
   // See `execCommand` in `libnpx` for specifics
+  // In npx v7 this option is deprecated
   '--always-spawn',
   // Yes, this is dangerous.
   // But I'm trying to replicate _just running npx_
@@ -44,6 +43,8 @@ const args = [
 ]
 
 spawn('npx', args, {
+    // npx v7 will *not* install from any repository if any version exists locally.
+    cwd: 'verdaccio/integration',
     // This instance of npx needs to target the verdaccio server
     // so the env var that governs this needs to be updated.
     // it is _possible_ for this value to already be set.

--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -84,5 +84,3 @@ middlewares:
 # log settings
 logs:
   - { type: stdout, format: pretty, level: http }
-  #- {type: file, path: verdaccio.log, level: info}
-

--- a/verdaccio/integration/Readme.md
+++ b/verdaccio/integration/Readme.md
@@ -1,0 +1,4 @@
+npx v7 will not install a newer version when any version is installed.
+This module is a place to run npx on our integration modules.
+
+see `util/npx-verdaccio` for more details

--- a/verdaccio/integration/package.json
+++ b/verdaccio/integration/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "integration",
+  "version": "1.0.0",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
*Issue #, if available:* Release 1.x

*Description of changes:*
Verdaccio was pulling the latest version of ESDK modules from NPM and testing thoses.
It would only test local modules if it detected changes, 
but something was wrong in the manner it detected changes.

Regardless, that is now fixed.
By back-porting changes to `util` and `verdaccio`, what ever we did on `master` to correctly 
test the ESDK with verdaccio has now been applied to mainline-1.x.

I confirmed that the local ESDK-JS's modules are being tested by inspecting verdaccio's storage:
```
ls verdaccio/storage/@aws-crypto/*/*.tgz
```
Some other fixes had to be applied:
1. Increasing the default time out for integration-browser testing
2. Fixing the `integration-browser` and `integration-node` dependence on `integration-vectors`
3. Updating the package lock for (2.) and correctly versioning the ESDK modules 
   (For some reason, the pakcage-lock had them versioned to 2.x?)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

