### PR TITLE
fix: set dist-tag to the major version to avoid overwriting latest ta…

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -57,7 +57,9 @@ phases:
       # This is going to use the OTP generated above and the NPM_TOKEN
       # environment variable. This will only publish things that are
       # missing from npm. It is therefore safe to run repeatedly.
-      - npx lerna publish from-package --yes --otp $OTP
+      # We make sure to specify a tag, otherwise the default is latest.
+      # This branch is no longer the latest MV so it must be avoided.
+      - npx lerna publish from-package --yes --otp $OTP --dist-tag '2.x'
       # remove after publishing
       - rm .npmrc
       # Clear out the verdaccio cache so that we get the latest version


### PR DESCRIPTION
…g on non-latest MV branch

*Issue #, if available:* https://github.com/aws/aws-encryption-sdk-javascript/issues/1034 (long term fix)

*Description of changes:* See the above issue. When we ran a release to retire 1.x, no tag was specified, so the default 
 was set to `latest` ([doc ref](https://www.npmjs.com/package/@lerna/publish#--dist-tag-tag)), overwriting from the actual latest `3.x` release. The `1.x` release is now retired, but `2.x` is not yet retired and will eventually need to be released, upon retirement or otherwise. 

This change sets the `dist-tag` to `2.x` for the CodeBuild spec in `2.x` to avoid the situation which occurred during `1.x` retirement. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

