### PR TITLE
chore: Add dist-tag to release

### DIFF
--- a/codebuild/release/publish.yml
+++ b/codebuild/release/publish.yml
@@ -4,6 +4,8 @@ env:
   variables:
     NODE_OPTIONS: "--max-old-space-size=4096"
     BRANCH: "master"
+    # An explicit distribution tag
+    DIST_TAG: "latest"
   secrets-manager:
      OTP_SECRET_KEY: npm/aws-crypto-tools-ci-bot/2FA:OTP_SECRET_KEY
      NPM_TOKEN: npm/aws-crypto-tools-ci-bot/2FA:NPM_TOKEN
@@ -42,7 +44,7 @@ phases:
       # This is going to use the OTP generated above and the NPM_TOKEN
       # environment variable. This will only publish things that are
       # missing from npm. It is therefore safe to run repeatedly.
-      - npx lerna publish from-package --yes --otp $OTP
+      - npx lerna publish from-package --yes --otp $OTP --dist-tag $DIST_TAG
       # remove after publishing
       - rm .npmrc
 


### PR DESCRIPTION
Currently the release build will _always_ add the `latest` tag to every release.
If a release is for an old version,
this will result in the wrong version being tagged as `latest`.

This ENV in the build allows for proper tagging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

