### PR TITLE
chore: Update package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## AWS Encryption SDK for Javascript
 
+
 The AWS Encryption SDK for Javascript provides a fully compliant,
 native Javascript implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ## AWS Encryption SDK for Javascript
 
-
 The AWS Encryption SDK for Javascript provides a fully compliant,
 native Javascript implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3951,9 +3951,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
+      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -6098,9 +6098,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "node_modules/@types/lru-cache": {
@@ -6383,14 +6383,48 @@
         "url": "https://opencollective.com/verdaccio"
       }
     },
-    "node_modules/@verdaccio/config": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-gvR6vRS5aXTwEhZSecqEEOlTGHqbV2Vjg7w/huGRuAuJlOuz2t4V3d499U4qkkLBBEhh/X+4DjEVrkOo+jVWzQ==",
+    "node_modules/@verdaccio/commons-api/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@verdaccio/commons-api/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@verdaccio/commons-api/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@verdaccio/config": {
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-NlwehhK7GSniqvPk9PG47vh0NGyPmCtLmgwOu5N3+aEZI6M7T/maqzPGbH21sjrDyL4nHp3suCbhxiIw2UV/cg==",
+      "dev": true,
+      "dependencies": {
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
@@ -6441,13 +6475,13 @@
       }
     },
     "node_modules/@verdaccio/core": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-F5TLiQB9leeoZnyKRcE1hH5pr3lD2hZsKoda4ljqPyN2SqQq6ni6VsJLIMU73WjRQSl8GU9FPs8VunZo7l5AyA==",
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-CujQ5oA8ORgkVbLJwcD6vzBitsYbIIyuJ9aizBDP3QXFyVEkr5g+fIZRvRPPEJhGXvHpfwuewDTWQ7P9wk/aRQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.2",
-        "core-js": "3.27.0",
+        "core-js": "3.28.0",
         "http-errors": "1.8.1",
         "http-status-codes": "2.2.0",
         "process-warning": "1.0.0",
@@ -6477,22 +6511,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@verdaccio/core/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/@verdaccio/core/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6500,15 +6518,15 @@
       "dev": true
     },
     "node_modules/@verdaccio/file-locking": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.0.tgz",
-      "integrity": "sha512-FE5D5H4wy/nhgR/d2J5e1Na9kScj2wMjlLPBHz7XF4XZAVSRdm45+kL3ZmrfA6b2HTADP/uH7H05/cnAYW8bhw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.1.tgz",
+      "integrity": "sha512-oqYLfv3Yg3mAgw9qhASBpjD50osj2AX4IwbkUtyuhhKGyoFU9eZdrbeW6tpnqUnj6yBMtAPm2eGD4BwQuX400g==",
       "dev": true,
       "dependencies": {
         "lockfile": "1.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "type": "opencollective",
@@ -6516,14 +6534,14 @@
       }
     },
     "node_modules/@verdaccio/local-storage": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage/-/local-storage-10.3.1.tgz",
-      "integrity": "sha512-f3oArjXPOAwUAA2dsBhfL/rSouqJ2sfml8k97RtnBPKOzisb28bgyAQW0mqwQvN4MTK5S/2xudmobFpvJAIatg==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage/-/local-storage-10.3.3.tgz",
+      "integrity": "sha512-/n0FH+1hxVg80YhYBfJuW7F2AuvLY2fra8/DTCilWDll9Y5yZDxwntZfcKHJLerCA4atrbJtvaqpWkoV3Q9x8w==",
       "dev": true,
       "dependencies": {
         "@verdaccio/commons-api": "10.2.0",
-        "@verdaccio/file-locking": "10.3.0",
-        "@verdaccio/streams": "10.2.0",
+        "@verdaccio/file-locking": "10.3.1",
+        "@verdaccio/streams": "10.2.1",
         "async": "3.2.4",
         "debug": "4.3.4",
         "lodash": "4.17.21",
@@ -6574,12 +6592,12 @@
       }
     },
     "node_modules/@verdaccio/logger-7": {
-      "version": "6.0.0-6-next.6",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-6.0.0-6-next.6.tgz",
-      "integrity": "sha512-Lkm/FCP5ALKfsje+y17FXnGpGI7mnAyzPlF+TA1ZkMXyVnRsQO0sbYfjOenkZ9/IpkEJzwq+15mzyvxZzVsWMA==",
+      "version": "6.0.0-6-next.13",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-6.0.0-6-next.13.tgz",
+      "integrity": "sha512-YaVH37AOiB7C9N9rCxW723N6DPTAYbCnj7G+Z1AOkLEd+r1JibH6ncwETKr07WVFFvlSwccQaC7auBFwWnp0xA==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/logger-commons": "6.0.0-6-next.29",
+        "@verdaccio/logger-commons": "6.0.0-6-next.36",
         "pino": "7.11.0"
       },
       "engines": {
@@ -6591,12 +6609,12 @@
       }
     },
     "node_modules/@verdaccio/logger-commons": {
-      "version": "6.0.0-6-next.29",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-6.0.0-6-next.29.tgz",
-      "integrity": "sha512-7AFWin5Kgurprr+7B/swOX4vbNxDWl/yzHAe6spSN3GXheX6mjsbgu8msovXvu0ntqehyEWeSgI30lOnB4vjKQ==",
+      "version": "6.0.0-6-next.36",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-6.0.0-6-next.36.tgz",
+      "integrity": "sha512-3ULwwd9RV72CK54Q1ugdWNDkVvuyrXgxotabX6MJ4NgF+FkFfFrDFGRnFwQmM7LhYDCCu5l6g+J7/5CohRWIIw==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "@verdaccio/logger-prettify": "6.0.0-6-next.9",
         "colorette": "2.0.19",
         "debug": "4.3.4"
@@ -6659,20 +6677,20 @@
       "dev": true
     },
     "node_modules/@verdaccio/middleware": {
-      "version": "6.0.0-6-next.40",
-      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-6.0.0-6-next.40.tgz",
-      "integrity": "sha512-j7VT0sHM8OGEz2L1Tmff6oSjh8uHm40z96enUtFxpAJYELXx8KqGK82DHHl5FsCIB8GvdbFJn0YM1Bv4Gf5bvA==",
+      "version": "6.0.0-6-next.47",
+      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-6.0.0-6-next.47.tgz",
+      "integrity": "sha512-IWy9QOYSjZxCZQPwDFcOZAI+FuFoHNRODrwC2n8PQwHSt/W8X3gB+uo8ofNH/5NmAo+ftI11MhckoGoRenw85Q==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/config": "6.0.0-6-next.61",
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "express": "4.18.2",
         "express-rate-limit": "5.5.1",
         "lodash": "4.17.21",
-        "lru-cache": "7.14.1",
+        "lru-cache": "7.16.1",
         "mime": "2.6.0"
       },
       "engines": {
@@ -6701,21 +6719,56 @@
       }
     },
     "node_modules/@verdaccio/middleware/node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
+      "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
       "dev": true,
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/@verdaccio/signature": {
+      "version": "6.0.0-6-next.2",
+      "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-6.0.0-6-next.2.tgz",
+      "integrity": "sha512-aFvMbxxHzJCpPmqSgVuQYvYN2RP11CoSEcTXikkyb1zF4Uf3cOy53zUZ1Y7iOKCRYTgWrmet9KP7+24e44GHxg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "jsonwebtoken": "9.0.0",
+        "lodash": "4.17.21"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/verdaccio"
+      }
+    },
+    "node_modules/@verdaccio/signature/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@verdaccio/streams": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.0.tgz",
-      "integrity": "sha512-FaIzCnDg0x0Js5kSQn1Le3YzDHl7XxrJ0QdIw5LrDUmLsH3VXNi4/NMlSHnw5RiTTMs4UbEf98V3RJRB8exqJA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.1.tgz",
+      "integrity": "sha512-OojIG/f7UYKxC4dYX8x5ax8QhRx1b8OYUAMz82rUottCuzrssX/4nn5QE7Ank0DUSX3C9l/HPthc4d9uKRJqJQ==",
       "dev": true,
       "engines": {
-        "node": ">=8",
+        "node": ">=12",
         "npm": ">=5"
       },
       "funding": {
@@ -6724,14 +6777,14 @@
       }
     },
     "node_modules/@verdaccio/tarball": {
-      "version": "11.0.0-6-next.30",
-      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-11.0.0-6-next.30.tgz",
-      "integrity": "sha512-+lQn0FsPkuTrZnzWxJ9p1ZuQlctZoDuxqH5y6UoOJP49OJSEV14NrVIR0y8mRhgJRFOfBjyqDEoyH4gNkhnNoA==",
+      "version": "11.0.0-6-next.37",
+      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-11.0.0-6-next.37.tgz",
+      "integrity": "sha512-UNFJCbn0r/TQe+j3HXVcr2/XPaHbp+tG/yeiz8euOY3Gn2qWQCrEK3I3p4C4QPdiUmzQtixe9s7I6qSyvcOaPQ==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "lodash": "4.17.21"
       },
@@ -6761,21 +6814,21 @@
       }
     },
     "node_modules/@verdaccio/ui-theme": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-owS9KpIrG69KjJ5zoQa55qGQPQUKzcWN/giRk6lMpU8LXAKS0Ogpr86mzL4IgKg8DEHsfo0DWiBeWwXwr8HHFA==",
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-ZfYLFVWXIk0wgEb8OtPPH6jrvg2ue5IptKWqN0FKdX8q5cVq8ZtCeZRroGypXTiTcLpQYRI1svo7QM2uynC6Gw==",
       "dev": true
     },
     "node_modules/@verdaccio/url": {
-      "version": "11.0.0-6-next.27",
-      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-11.0.0-6-next.27.tgz",
-      "integrity": "sha512-Gj29AkqUZbpbGyN6vXxKejZt6lQBWhEmLHN6ajZgfmr/hqbTzx2VTetFIIFfuka72mHCOhnUn/hBFgh9fL1Hxw==",
+      "version": "11.0.0-6-next.34",
+      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-11.0.0-6-next.34.tgz",
+      "integrity": "sha512-uGtyCV/LjlBYZkUkn64Ryy6OdMv77ILICtRzVT5j2r9rxpcIVoWfKmxcmr4yQF+WC7bXpUJ2cXSjDyVSA0fdag==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "debug": "4.3.4",
         "lodash": "4.17.21",
-        "validator": "13.7.0"
+        "validator": "13.9.0"
       },
       "engines": {
         "node": ">=12"
@@ -6803,12 +6856,12 @@
       }
     },
     "node_modules/@verdaccio/utils": {
-      "version": "6.0.0-6-next.29",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.29.tgz",
-      "integrity": "sha512-bIpZYaWTT+bKyUDyoTQxkGDd8us65o9OJtVLIKCrH2RKxpX5ONpwPCxemyFB8v5kErSbqRXXvvQQflbg3s+WHg==",
+      "version": "6.0.0-6-next.36",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.36.tgz",
+      "integrity": "sha512-AgL0xVugv53quqn2F085aK/vt2NcWloKkQoNz7CYyo2Hg4rwDqIKxnKLv7dFeUYil6l3mkArWyBRkaaTJtuqDw==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "lodash": "4.17.21",
         "minimatch": "3.1.2",
         "semver": "7.3.8"
@@ -7388,24 +7441,35 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-sdk": {
-      "version": "2.1016.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1016.0.tgz",
-      "integrity": "sha512-6QY4sJBMtPzxJdzSMjmf22mASZ9RO7e5QjW4PMYI5PVal+jPdl7h37IbtC7abmWNgMubIQ1SIBoUktRQGIE8tw==",
-      "hasInstallScript": true,
+      "version": "2.1390.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1390.0.tgz",
+      "integrity": "sha512-oY1kbL0eeOVIc2dBbzQpjdQ6H1frY2d/9fprC1Z5DWHmsq6f8AeB94/B8a8t8k/X0u+W7ZMuEwEDrndef9KwCw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/aws-sdk/node_modules/buffer": {
@@ -7432,12 +7496,11 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/aws-sign2": {
@@ -7450,9 +7513,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "node_modules/balanced-match": {
@@ -7626,12 +7689,12 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -7639,7 +7702,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -7664,6 +7727,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -7676,6 +7754,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8183,9 +8269,9 @@
       }
     },
     "node_modules/clipanion": {
-      "version": "3.2.0-rc.14",
-      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0-rc.14.tgz",
-      "integrity": "sha512-lj5zydbH786t6gpXe6oNX7CM5YKhd0CDhcXG8pKyRa2Nz5cgj1yhnNKxDi/MyPYwjyvAG5oVBeDdYCGUAgD8lQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0.tgz",
+      "integrity": "sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==",
       "dev": true,
       "dependencies": {
         "typanion": "^3.8.0"
@@ -8517,9 +8603,9 @@
       ]
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8704,9 +8790,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.0.tgz",
-      "integrity": "sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -9816,6 +9902,30 @@
       "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==",
       "dev": true
     },
+    "node_modules/express/node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -9861,6 +9971,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -9874,6 +10000,21 @@
       "dev": true,
       "dependencies": {
         "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -9980,9 +10121,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-redact": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
-      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -10197,6 +10338,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -10217,6 +10366,20 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -10387,13 +10550,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10672,6 +10836,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/got": {
       "version": "11.8.5",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
@@ -10798,10 +10973,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10813,7 +10999,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -10906,34 +11091,19 @@
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
       "dependencies": {
-        "depd": "2.0.0",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/http-proxy": {
@@ -11311,6 +11481,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -11360,7 +11545,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11435,6 +11619,20 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -11625,6 +11823,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -11960,9 +12176,9 @@
       }
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -15409,9 +15625,9 @@
       }
     },
     "node_modules/pino-abstract-transport/node_modules/readable-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -15424,9 +15640,9 @@
       }
     },
     "node_modules/pino-abstract-transport/node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -15458,9 +15674,9 @@
       }
     },
     "node_modules/pino/node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -15808,15 +16024,46 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -16262,9 +16509,9 @@
       }
     },
     "node_modules/request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
@@ -16275,7 +16522,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -16285,33 +16532,13 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 6"
       }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
     },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.3",
@@ -16320,19 +16547,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/request/node_modules/uuid": {
@@ -16526,9 +16740,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -16626,6 +16840,22 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
       "engines": {
         "node": ">= 0.8"
       }
@@ -16816,9 +17046,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -17638,6 +17868,19 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/treeverse": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-2.0.0.tgz",
@@ -18033,6 +18276,18 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18082,9 +18337,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -18099,30 +18354,32 @@
       }
     },
     "node_modules/verdaccio": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.21.1.tgz",
-      "integrity": "sha512-SbqeKxmcUW1G9AYo8cmAPAlWW6YpNR8Q6LVJrfP+4s9gQ496s8cvhj0yAX8nl1k3+DAEZBuGcrgfAF0kORYXpA==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.24.1.tgz",
+      "integrity": "sha512-PxJClisu2KvNi+L5QG3vaTje3hpS0Ow8/xAzvVzVeO/QFFbNG/mQ6EVUfSewSprrTsFcx1ERCEBSJLQt1RP3HQ==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/config": "6.0.0-6-next.61",
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/local-storage": "10.3.1",
-        "@verdaccio/logger-7": "6.0.0-6-next.6",
-        "@verdaccio/middleware": "6.0.0-6-next.40",
-        "@verdaccio/streams": "10.2.0",
-        "@verdaccio/tarball": "11.0.0-6-next.30",
-        "@verdaccio/ui-theme": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/local-storage": "10.3.3",
+        "@verdaccio/logger-7": "6.0.0-6-next.13",
+        "@verdaccio/middleware": "6.0.0-6-next.47",
+        "@verdaccio/signature": "6.0.0-6-next.2",
+        "@verdaccio/streams": "10.2.1",
+        "@verdaccio/tarball": "11.0.0-6-next.37",
+        "@verdaccio/ui-theme": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "async": "3.2.4",
-        "body-parser": "1.20.1",
-        "clipanion": "3.2.0-rc.14",
+        "body-parser": "1.20.2",
+        "clipanion": "3.2.0",
         "compression": "1.7.4",
         "cookies": "0.8.0",
         "cors": "2.8.5",
         "debug": "^4.3.4",
         "envinfo": "7.8.1",
         "express": "4.18.2",
+        "express-rate-limit": "5.5.1",
         "fast-safe-stringify": "2.1.1",
         "handlebars": "4.7.7",
         "js-yaml": "4.1.0",
@@ -18130,16 +18387,17 @@
         "jsonwebtoken": "9.0.0",
         "kleur": "4.1.5",
         "lodash": "4.17.21",
+        "lru-cache": "7.18.3",
         "lunr-mutable-indexes": "2.3.2",
         "mime": "3.0.0",
         "mkdirp": "1.0.4",
         "mv": "2.1.1",
         "pkginfo": "0.4.1",
-        "request": "2.88.0",
-        "semver": "7.3.8",
-        "validator": "13.7.0",
-        "verdaccio-audit": "11.0.0-6-next.23",
-        "verdaccio-htpasswd": "10.5.2"
+        "request": "2.88.2",
+        "semver": "7.5.0",
+        "validator": "13.9.0",
+        "verdaccio-audit": "11.0.0-6-next.31",
+        "verdaccio-htpasswd": "11.0.0-6-next.38"
       },
       "bin": {
         "verdaccio": "bin/verdaccio"
@@ -18153,13 +18411,13 @@
       }
     },
     "node_modules/verdaccio-audit": {
-      "version": "11.0.0-6-next.23",
-      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-11.0.0-6-next.23.tgz",
-      "integrity": "sha512-4TmBfglknSIgLVKUOrhx9ArtI715Ju2SJnyoP0e7DIM1vEdw3Njt1GTG44L47r+n+rB7I6rsrM0/MxKffUmjNQ==",
+      "version": "11.0.0-6-next.31",
+      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-11.0.0-6-next.31.tgz",
+      "integrity": "sha512-UCDIYAxJKbzGsLhhsRcO/z6y/MTg7yg30gNj3UaNL1ZZor+1p1fPhBQICXK2pP0G0JI4CV5YUpzPHkez75GdnA==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/config": "6.0.0-6-next.60",
-        "@verdaccio/core": "6.0.0-6-next.60",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "express": "4.18.2",
         "https-proxy-agent": "5.0.1",
         "node-fetch": "cjs"
@@ -18172,40 +18430,37 @@
         "url": "https://opencollective.com/verdaccio"
       }
     },
-    "node_modules/verdaccio-audit/node_modules/@verdaccio/config": {
-      "version": "6.0.0-6-next.60",
-      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.60.tgz",
-      "integrity": "sha512-q6r8JEXUV2piZUtWW5SR11vIVqO4b4OGKmAnwCf6EdszRoRcxzf9KBlktVxSzmoIUOvygf0a+3hGbGI9qZBSjw==",
+    "node_modules/verdaccio-htpasswd": {
+      "version": "11.0.0-6-next.38",
+      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-11.0.0-6-next.38.tgz",
+      "integrity": "sha512-g0M4fLkSbBzgSFrlOwVZXdaTz9sOm5TMtqCX/CcQf/SEOYaRgDEcD9m2JqKVKW0mM9aJlGjZJSJsfRyy4OGMvA==",
       "dev": true,
       "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.60",
-        "@verdaccio/utils": "6.0.0-6-next.28",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/file-locking": "11.0.0-6-next.7",
+        "apache-md5": "1.1.8",
+        "bcryptjs": "2.4.3",
+        "core-js": "3.28.0",
         "debug": "4.3.4",
-        "lodash": "4.17.21",
-        "minimatch": "3.1.2",
-        "yaml": "2.2.0",
-        "yup": "0.32.11"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/verdaccio"
-      }
-    },
-    "node_modules/verdaccio-audit/node_modules/@verdaccio/core": {
-      "version": "6.0.0-6-next.60",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.60.tgz",
-      "integrity": "sha512-ZCDOPGjC1rox2dKwZ38GyWA3muA5JlTSfJ15EoIzd8kkWekGtV4/qtua0xUoxH4MhrYQmycsMuelaRveDtSz9A==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "8.11.2",
-        "core-js": "3.27.0",
         "http-errors": "1.8.1",
-        "http-status-codes": "2.2.0",
-        "process-warning": "1.0.0",
-        "semver": "7.3.8"
+        "unix-crypt-td-js": "1.1.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/verdaccio"
+      }
+    },
+    "node_modules/verdaccio-htpasswd/node_modules/@verdaccio/file-locking": {
+      "version": "11.0.0-6-next.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-11.0.0-6-next.7.tgz",
+      "integrity": "sha512-S0GNoe2oBOgB7fKJN2vZqnl5qDEvdnTfKAfa47InXweJROeul6kjlE2/NlbNbK3zZID01VR1HFrFehMQO0Jyfw==",
+      "dev": true,
+      "dependencies": {
+        "lockfile": "1.0.4"
       },
       "engines": {
         "node": ">=12"
@@ -18215,42 +18470,7 @@
         "url": "https://opencollective.com/verdaccio"
       }
     },
-    "node_modules/verdaccio-audit/node_modules/@verdaccio/utils": {
-      "version": "6.0.0-6-next.28",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.28.tgz",
-      "integrity": "sha512-tEGIC7iYiDxZnrdBFB6O1cOdYOyeqE42MO4edtNLugbvAgh5iAntUI4qAGic8a39Od5JBm7QQ0RU3qHiofyU1w==",
-      "dev": true,
-      "dependencies": {
-        "@verdaccio/core": "6.0.0-6-next.60",
-        "lodash": "4.17.21",
-        "minimatch": "3.1.2",
-        "semver": "7.3.8"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/verdaccio"
-      }
-    },
-    "node_modules/verdaccio-audit/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/verdaccio-audit/node_modules/debug": {
+    "node_modules/verdaccio-htpasswd/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
@@ -18265,57 +18485,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/verdaccio-audit/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/verdaccio-audit/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/verdaccio-audit/node_modules/yaml": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.0.tgz",
-      "integrity": "sha512-auf7Gi6QwO7HW//GA9seGvTXVGWl1CM/ADWh1+RxtXr6XOxnT65ovDl9fTi4e0monEyJxCHqDpF6QnFDXmJE4g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/verdaccio-htpasswd": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-10.5.2.tgz",
-      "integrity": "sha512-bO5Wm8w07pWswNvwFWjNEoznuUU37CcfblcrU0Ci8c038EgTu2V47uwh4AyZ4PTK6ps9oxHqA7a1b+83sY0OkA==",
-      "dev": true,
-      "dependencies": {
-        "@verdaccio/file-locking": "10.3.0",
-        "apache-md5": "1.1.8",
-        "bcryptjs": "2.4.3",
-        "http-errors": "2.0.0",
-        "unix-crypt-td-js": "1.1.4"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/verdaccio"
       }
     },
     "node_modules/verdaccio/node_modules/argparse": {
@@ -18359,6 +18528,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/verdaccio/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/verdaccio/node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -18378,6 +18556,33 @@
       "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/verdaccio/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/verdaccio/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -18631,6 +18836,25 @@
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -18850,18 +19074,21 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
       }
@@ -22218,9 +22445,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
+      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
@@ -23970,9 +24197,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "@types/lru-cache": {
@@ -24165,16 +24392,43 @@
       "requires": {
         "http-errors": "2.0.0",
         "http-status-codes": "2.2.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        }
       }
     },
     "@verdaccio/config": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-gvR6vRS5aXTwEhZSecqEEOlTGHqbV2Vjg7w/huGRuAuJlOuz2t4V3d499U4qkkLBBEhh/X+4DjEVrkOo+jVWzQ==",
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-NlwehhK7GSniqvPk9PG47vh0NGyPmCtLmgwOu5N3+aEZI6M7T/maqzPGbH21sjrDyL4nHp3suCbhxiIw2UV/cg==",
       "dev": true,
       "requires": {
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
@@ -24209,13 +24463,13 @@
       }
     },
     "@verdaccio/core": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-F5TLiQB9leeoZnyKRcE1hH5pr3lD2hZsKoda4ljqPyN2SqQq6ni6VsJLIMU73WjRQSl8GU9FPs8VunZo7l5AyA==",
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-CujQ5oA8ORgkVbLJwcD6vzBitsYbIIyuJ9aizBDP3QXFyVEkr5g+fIZRvRPPEJhGXvHpfwuewDTWQ7P9wk/aRQ==",
       "dev": true,
       "requires": {
         "ajv": "8.11.2",
-        "core-js": "3.27.0",
+        "core-js": "3.28.0",
         "http-errors": "1.8.1",
         "http-status-codes": "2.2.0",
         "process-warning": "1.0.0",
@@ -24234,19 +24488,6 @@
             "uri-js": "^4.2.2"
           }
         },
-        "http-errors": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.1"
-          }
-        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -24256,23 +24497,23 @@
       }
     },
     "@verdaccio/file-locking": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.0.tgz",
-      "integrity": "sha512-FE5D5H4wy/nhgR/d2J5e1Na9kScj2wMjlLPBHz7XF4XZAVSRdm45+kL3ZmrfA6b2HTADP/uH7H05/cnAYW8bhw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.1.tgz",
+      "integrity": "sha512-oqYLfv3Yg3mAgw9qhASBpjD50osj2AX4IwbkUtyuhhKGyoFU9eZdrbeW6tpnqUnj6yBMtAPm2eGD4BwQuX400g==",
       "dev": true,
       "requires": {
         "lockfile": "1.0.4"
       }
     },
     "@verdaccio/local-storage": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage/-/local-storage-10.3.1.tgz",
-      "integrity": "sha512-f3oArjXPOAwUAA2dsBhfL/rSouqJ2sfml8k97RtnBPKOzisb28bgyAQW0mqwQvN4MTK5S/2xudmobFpvJAIatg==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage/-/local-storage-10.3.3.tgz",
+      "integrity": "sha512-/n0FH+1hxVg80YhYBfJuW7F2AuvLY2fra8/DTCilWDll9Y5yZDxwntZfcKHJLerCA4atrbJtvaqpWkoV3Q9x8w==",
       "dev": true,
       "requires": {
         "@verdaccio/commons-api": "10.2.0",
-        "@verdaccio/file-locking": "10.3.0",
-        "@verdaccio/streams": "10.2.0",
+        "@verdaccio/file-locking": "10.3.1",
+        "@verdaccio/streams": "10.2.1",
         "async": "3.2.4",
         "debug": "4.3.4",
         "lodash": "4.17.21",
@@ -24304,22 +24545,22 @@
       }
     },
     "@verdaccio/logger-7": {
-      "version": "6.0.0-6-next.6",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-6.0.0-6-next.6.tgz",
-      "integrity": "sha512-Lkm/FCP5ALKfsje+y17FXnGpGI7mnAyzPlF+TA1ZkMXyVnRsQO0sbYfjOenkZ9/IpkEJzwq+15mzyvxZzVsWMA==",
+      "version": "6.0.0-6-next.13",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-6.0.0-6-next.13.tgz",
+      "integrity": "sha512-YaVH37AOiB7C9N9rCxW723N6DPTAYbCnj7G+Z1AOkLEd+r1JibH6ncwETKr07WVFFvlSwccQaC7auBFwWnp0xA==",
       "dev": true,
       "requires": {
-        "@verdaccio/logger-commons": "6.0.0-6-next.29",
+        "@verdaccio/logger-commons": "6.0.0-6-next.36",
         "pino": "7.11.0"
       }
     },
     "@verdaccio/logger-commons": {
-      "version": "6.0.0-6-next.29",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-6.0.0-6-next.29.tgz",
-      "integrity": "sha512-7AFWin5Kgurprr+7B/swOX4vbNxDWl/yzHAe6spSN3GXheX6mjsbgu8msovXvu0ntqehyEWeSgI30lOnB4vjKQ==",
+      "version": "6.0.0-6-next.36",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-6.0.0-6-next.36.tgz",
+      "integrity": "sha512-3ULwwd9RV72CK54Q1ugdWNDkVvuyrXgxotabX6MJ4NgF+FkFfFrDFGRnFwQmM7LhYDCCu5l6g+J7/5CohRWIIw==",
       "dev": true,
       "requires": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "@verdaccio/logger-prettify": "6.0.0-6-next.9",
         "colorette": "2.0.19",
         "debug": "4.3.4"
@@ -24364,20 +24605,20 @@
       }
     },
     "@verdaccio/middleware": {
-      "version": "6.0.0-6-next.40",
-      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-6.0.0-6-next.40.tgz",
-      "integrity": "sha512-j7VT0sHM8OGEz2L1Tmff6oSjh8uHm40z96enUtFxpAJYELXx8KqGK82DHHl5FsCIB8GvdbFJn0YM1Bv4Gf5bvA==",
+      "version": "6.0.0-6-next.47",
+      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-6.0.0-6-next.47.tgz",
+      "integrity": "sha512-IWy9QOYSjZxCZQPwDFcOZAI+FuFoHNRODrwC2n8PQwHSt/W8X3gB+uo8ofNH/5NmAo+ftI11MhckoGoRenw85Q==",
       "dev": true,
       "requires": {
-        "@verdaccio/config": "6.0.0-6-next.61",
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "express": "4.18.2",
         "express-rate-limit": "5.5.1",
         "lodash": "4.17.21",
-        "lru-cache": "7.14.1",
+        "lru-cache": "7.16.1",
         "mime": "2.6.0"
       },
       "dependencies": {
@@ -24391,28 +24632,50 @@
           }
         },
         "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+          "version": "7.16.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
+          "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
           "dev": true
         }
       }
     },
+    "@verdaccio/signature": {
+      "version": "6.0.0-6-next.2",
+      "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-6.0.0-6-next.2.tgz",
+      "integrity": "sha512-aFvMbxxHzJCpPmqSgVuQYvYN2RP11CoSEcTXikkyb1zF4Uf3cOy53zUZ1Y7iOKCRYTgWrmet9KP7+24e44GHxg==",
+      "dev": true,
+      "requires": {
+        "debug": "4.3.4",
+        "jsonwebtoken": "9.0.0",
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "@verdaccio/streams": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.0.tgz",
-      "integrity": "sha512-FaIzCnDg0x0Js5kSQn1Le3YzDHl7XxrJ0QdIw5LrDUmLsH3VXNi4/NMlSHnw5RiTTMs4UbEf98V3RJRB8exqJA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.1.tgz",
+      "integrity": "sha512-OojIG/f7UYKxC4dYX8x5ax8QhRx1b8OYUAMz82rUottCuzrssX/4nn5QE7Ank0DUSX3C9l/HPthc4d9uKRJqJQ==",
       "dev": true
     },
     "@verdaccio/tarball": {
-      "version": "11.0.0-6-next.30",
-      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-11.0.0-6-next.30.tgz",
-      "integrity": "sha512-+lQn0FsPkuTrZnzWxJ9p1ZuQlctZoDuxqH5y6UoOJP49OJSEV14NrVIR0y8mRhgJRFOfBjyqDEoyH4gNkhnNoA==",
+      "version": "11.0.0-6-next.37",
+      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-11.0.0-6-next.37.tgz",
+      "integrity": "sha512-UNFJCbn0r/TQe+j3HXVcr2/XPaHbp+tG/yeiz8euOY3Gn2qWQCrEK3I3p4C4QPdiUmzQtixe9s7I6qSyvcOaPQ==",
       "dev": true,
       "requires": {
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "debug": "4.3.4",
         "lodash": "4.17.21"
       },
@@ -24429,21 +24692,21 @@
       }
     },
     "@verdaccio/ui-theme": {
-      "version": "6.0.0-6-next.61",
-      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-6.0.0-6-next.61.tgz",
-      "integrity": "sha512-owS9KpIrG69KjJ5zoQa55qGQPQUKzcWN/giRk6lMpU8LXAKS0Ogpr86mzL4IgKg8DEHsfo0DWiBeWwXwr8HHFA==",
+      "version": "6.0.0-6-next.68",
+      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-6.0.0-6-next.68.tgz",
+      "integrity": "sha512-ZfYLFVWXIk0wgEb8OtPPH6jrvg2ue5IptKWqN0FKdX8q5cVq8ZtCeZRroGypXTiTcLpQYRI1svo7QM2uynC6Gw==",
       "dev": true
     },
     "@verdaccio/url": {
-      "version": "11.0.0-6-next.27",
-      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-11.0.0-6-next.27.tgz",
-      "integrity": "sha512-Gj29AkqUZbpbGyN6vXxKejZt6lQBWhEmLHN6ajZgfmr/hqbTzx2VTetFIIFfuka72mHCOhnUn/hBFgh9fL1Hxw==",
+      "version": "11.0.0-6-next.34",
+      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-11.0.0-6-next.34.tgz",
+      "integrity": "sha512-uGtyCV/LjlBYZkUkn64Ryy6OdMv77ILICtRzVT5j2r9rxpcIVoWfKmxcmr4yQF+WC7bXpUJ2cXSjDyVSA0fdag==",
       "dev": true,
       "requires": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "debug": "4.3.4",
         "lodash": "4.17.21",
-        "validator": "13.7.0"
+        "validator": "13.9.0"
       },
       "dependencies": {
         "debug": {
@@ -24458,12 +24721,12 @@
       }
     },
     "@verdaccio/utils": {
-      "version": "6.0.0-6-next.29",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.29.tgz",
-      "integrity": "sha512-bIpZYaWTT+bKyUDyoTQxkGDd8us65o9OJtVLIKCrH2RKxpX5ONpwPCxemyFB8v5kErSbqRXXvvQQflbg3s+WHg==",
+      "version": "6.0.0-6-next.36",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.36.tgz",
+      "integrity": "sha512-AgL0xVugv53quqn2F085aK/vt2NcWloKkQoNz7CYyo2Hg4rwDqIKxnKLv7dFeUYil6l3mkArWyBRkaaTJtuqDw==",
       "dev": true,
       "requires": {
-        "@verdaccio/core": "6.0.0-6-next.61",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "lodash": "4.17.21",
         "minimatch": "3.1.2",
         "semver": "7.3.8"
@@ -24932,20 +25195,26 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
     "aws-sdk": {
-      "version": "2.1016.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1016.0.tgz",
-      "integrity": "sha512-6QY4sJBMtPzxJdzSMjmf22mASZ9RO7e5QjW4PMYI5PVal+jPdl7h37IbtC7abmWNgMubIQ1SIBoUktRQGIE8tw==",
+      "version": "2.1390.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1390.0.tgz",
+      "integrity": "sha512-oY1kbL0eeOVIc2dBbzQpjdQ6H1frY2d/9fprC1Z5DWHmsq6f8AeB94/B8a8t8k/X0u+W7ZMuEwEDrndef9KwCw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
       },
       "dependencies": {
         "buffer": {
@@ -24969,9 +25238,9 @@
           "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
         }
       }
     },
@@ -24982,9 +25251,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "balanced-match": {
@@ -25110,12 +25379,12 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -25123,7 +25392,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -25141,6 +25410,18 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -25153,6 +25434,11 @@
           "requires": {
             "ee-first": "1.1.1"
           }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
     },
@@ -25513,9 +25799,9 @@
       "dev": true
     },
     "clipanion": {
-      "version": "3.2.0-rc.14",
-      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0-rc.14.tgz",
-      "integrity": "sha512-lj5zydbH786t6gpXe6oNX7CM5YKhd0CDhcXG8pKyRa2Nz5cgj1yhnNKxDi/MyPYwjyvAG5oVBeDdYCGUAgD8lQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0.tgz",
+      "integrity": "sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==",
       "dev": true,
       "requires": {
         "typanion": "^3.8.0"
@@ -25791,9 +26077,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "conventional-changelog-angular": {
       "version": "5.0.13",
@@ -25937,9 +26223,9 @@
       }
     },
     "core-js": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.0.tgz",
-      "integrity": "sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true
     },
     "core-util-is": {
@@ -26790,6 +27076,26 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.11.0",
+            "raw-body": "2.5.1",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          }
+        },
         "cookie": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -26826,6 +27132,19 @@
             "unpipe": "~1.0.0"
           }
         },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -26839,6 +27158,18 @@
           "dev": true,
           "requires": {
             "ee-first": "1.1.1"
+          }
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
           }
         },
         "safe-buffer": {
@@ -26923,9 +27254,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-redact": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
-      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -27084,6 +27415,14 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -27099,6 +27438,17 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -27220,13 +27570,14 @@
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -27436,6 +27787,14 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "got": {
       "version": "11.8.5",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
@@ -27525,16 +27884,20 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+    },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -27608,27 +27971,16 @@
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
       "requires": {
-        "depd": "2.0.0",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-        }
       }
     },
     "http-proxy": {
@@ -27915,6 +28267,15 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -27951,8 +28312,7 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -27995,6 +28355,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -28121,6 +28489,18 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -28376,9 +28756,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -31033,9 +31413,9 @@
           }
         },
         "split2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
           "dev": true
         }
       }
@@ -31051,9 +31431,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-          "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+          "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
           "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
@@ -31063,9 +31443,9 @@
           }
         },
         "split2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
           "dev": true
         }
       }
@@ -31326,14 +31706,38 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+        }
       }
     },
     "read": {
@@ -31682,9 +32086,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -31694,7 +32098,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -31704,43 +32108,16 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-          "dev": true
-        },
         "qs": {
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
           "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
           "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
         },
         "uuid": {
           "version": "3.4.0",
@@ -31884,9 +32261,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-stable-stringify": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true
     },
     "safer-buffer": {
@@ -31967,6 +32344,19 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
         },
         "mime": {
           "version": "1.6.0",
@@ -32116,9 +32506,9 @@
       }
     },
     "socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -32751,6 +33141,16 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "treeverse": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-2.0.0.tgz",
@@ -33030,6 +33430,18 @@
         }
       }
     },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -33070,9 +33482,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "dev": true
     },
     "vary": {
@@ -33081,30 +33493,32 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "verdaccio": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.21.1.tgz",
-      "integrity": "sha512-SbqeKxmcUW1G9AYo8cmAPAlWW6YpNR8Q6LVJrfP+4s9gQ496s8cvhj0yAX8nl1k3+DAEZBuGcrgfAF0kORYXpA==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.24.1.tgz",
+      "integrity": "sha512-PxJClisu2KvNi+L5QG3vaTje3hpS0Ow8/xAzvVzVeO/QFFbNG/mQ6EVUfSewSprrTsFcx1ERCEBSJLQt1RP3HQ==",
       "dev": true,
       "requires": {
-        "@verdaccio/config": "6.0.0-6-next.61",
-        "@verdaccio/core": "6.0.0-6-next.61",
-        "@verdaccio/local-storage": "10.3.1",
-        "@verdaccio/logger-7": "6.0.0-6-next.6",
-        "@verdaccio/middleware": "6.0.0-6-next.40",
-        "@verdaccio/streams": "10.2.0",
-        "@verdaccio/tarball": "11.0.0-6-next.30",
-        "@verdaccio/ui-theme": "6.0.0-6-next.61",
-        "@verdaccio/url": "11.0.0-6-next.27",
-        "@verdaccio/utils": "6.0.0-6-next.29",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/local-storage": "10.3.3",
+        "@verdaccio/logger-7": "6.0.0-6-next.13",
+        "@verdaccio/middleware": "6.0.0-6-next.47",
+        "@verdaccio/signature": "6.0.0-6-next.2",
+        "@verdaccio/streams": "10.2.1",
+        "@verdaccio/tarball": "11.0.0-6-next.37",
+        "@verdaccio/ui-theme": "6.0.0-6-next.68",
+        "@verdaccio/url": "11.0.0-6-next.34",
+        "@verdaccio/utils": "6.0.0-6-next.36",
         "async": "3.2.4",
-        "body-parser": "1.20.1",
-        "clipanion": "3.2.0-rc.14",
+        "body-parser": "1.20.2",
+        "clipanion": "3.2.0",
         "compression": "1.7.4",
         "cookies": "0.8.0",
         "cors": "2.8.5",
         "debug": "^4.3.4",
         "envinfo": "7.8.1",
         "express": "4.18.2",
+        "express-rate-limit": "5.5.1",
         "fast-safe-stringify": "2.1.1",
         "handlebars": "4.7.7",
         "js-yaml": "4.1.0",
@@ -33112,16 +33526,17 @@
         "jsonwebtoken": "9.0.0",
         "kleur": "4.1.5",
         "lodash": "4.17.21",
+        "lru-cache": "7.18.3",
         "lunr-mutable-indexes": "2.3.2",
         "mime": "3.0.0",
         "mkdirp": "1.0.4",
         "mv": "2.1.1",
         "pkginfo": "0.4.1",
-        "request": "2.88.0",
-        "semver": "7.3.8",
-        "validator": "13.7.0",
-        "verdaccio-audit": "11.0.0-6-next.23",
-        "verdaccio-htpasswd": "10.5.2"
+        "request": "2.88.2",
+        "semver": "7.5.0",
+        "validator": "13.9.0",
+        "verdaccio-audit": "11.0.0-6-next.31",
+        "verdaccio-htpasswd": "11.0.0-6-next.38"
       },
       "dependencies": {
         "argparse": {
@@ -33154,6 +33569,12 @@
             "argparse": "^2.0.1"
           }
         },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        },
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -33165,73 +33586,65 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
+        },
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
+          }
         }
       }
     },
     "verdaccio-audit": {
-      "version": "11.0.0-6-next.23",
-      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-11.0.0-6-next.23.tgz",
-      "integrity": "sha512-4TmBfglknSIgLVKUOrhx9ArtI715Ju2SJnyoP0e7DIM1vEdw3Njt1GTG44L47r+n+rB7I6rsrM0/MxKffUmjNQ==",
+      "version": "11.0.0-6-next.31",
+      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-11.0.0-6-next.31.tgz",
+      "integrity": "sha512-UCDIYAxJKbzGsLhhsRcO/z6y/MTg7yg30gNj3UaNL1ZZor+1p1fPhBQICXK2pP0G0JI4CV5YUpzPHkez75GdnA==",
       "dev": true,
       "requires": {
-        "@verdaccio/config": "6.0.0-6-next.60",
-        "@verdaccio/core": "6.0.0-6-next.60",
+        "@verdaccio/config": "6.0.0-6-next.68",
+        "@verdaccio/core": "6.0.0-6-next.68",
         "express": "4.18.2",
         "https-proxy-agent": "5.0.1",
         "node-fetch": "cjs"
+      }
+    },
+    "verdaccio-htpasswd": {
+      "version": "11.0.0-6-next.38",
+      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-11.0.0-6-next.38.tgz",
+      "integrity": "sha512-g0M4fLkSbBzgSFrlOwVZXdaTz9sOm5TMtqCX/CcQf/SEOYaRgDEcD9m2JqKVKW0mM9aJlGjZJSJsfRyy4OGMvA==",
+      "dev": true,
+      "requires": {
+        "@verdaccio/core": "6.0.0-6-next.68",
+        "@verdaccio/file-locking": "11.0.0-6-next.7",
+        "apache-md5": "1.1.8",
+        "bcryptjs": "2.4.3",
+        "core-js": "3.28.0",
+        "debug": "4.3.4",
+        "http-errors": "1.8.1",
+        "unix-crypt-td-js": "1.1.4"
       },
       "dependencies": {
-        "@verdaccio/config": {
-          "version": "6.0.0-6-next.60",
-          "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-6.0.0-6-next.60.tgz",
-          "integrity": "sha512-q6r8JEXUV2piZUtWW5SR11vIVqO4b4OGKmAnwCf6EdszRoRcxzf9KBlktVxSzmoIUOvygf0a+3hGbGI9qZBSjw==",
+        "@verdaccio/file-locking": {
+          "version": "11.0.0-6-next.7",
+          "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-11.0.0-6-next.7.tgz",
+          "integrity": "sha512-S0GNoe2oBOgB7fKJN2vZqnl5qDEvdnTfKAfa47InXweJROeul6kjlE2/NlbNbK3zZID01VR1HFrFehMQO0Jyfw==",
           "dev": true,
           "requires": {
-            "@verdaccio/core": "6.0.0-6-next.60",
-            "@verdaccio/utils": "6.0.0-6-next.28",
-            "debug": "4.3.4",
-            "lodash": "4.17.21",
-            "minimatch": "3.1.2",
-            "yaml": "2.2.0",
-            "yup": "0.32.11"
-          }
-        },
-        "@verdaccio/core": {
-          "version": "6.0.0-6-next.60",
-          "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-6.0.0-6-next.60.tgz",
-          "integrity": "sha512-ZCDOPGjC1rox2dKwZ38GyWA3muA5JlTSfJ15EoIzd8kkWekGtV4/qtua0xUoxH4MhrYQmycsMuelaRveDtSz9A==",
-          "dev": true,
-          "requires": {
-            "ajv": "8.11.2",
-            "core-js": "3.27.0",
-            "http-errors": "1.8.1",
-            "http-status-codes": "2.2.0",
-            "process-warning": "1.0.0",
-            "semver": "7.3.8"
-          }
-        },
-        "@verdaccio/utils": {
-          "version": "6.0.0-6-next.28",
-          "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-6.0.0-6-next.28.tgz",
-          "integrity": "sha512-tEGIC7iYiDxZnrdBFB6O1cOdYOyeqE42MO4edtNLugbvAgh5iAntUI4qAGic8a39Od5JBm7QQ0RU3qHiofyU1w==",
-          "dev": true,
-          "requires": {
-            "@verdaccio/core": "6.0.0-6-next.60",
-            "lodash": "4.17.21",
-            "minimatch": "3.1.2",
-            "semver": "7.3.8"
-          }
-        },
-        "ajv": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "lockfile": "1.0.4"
           }
         },
         "debug": {
@@ -33242,45 +33655,7 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "http-errors": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.1"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.0.tgz",
-          "integrity": "sha512-auf7Gi6QwO7HW//GA9seGvTXVGWl1CM/ADWh1+RxtXr6XOxnT65ovDl9fTi4e0monEyJxCHqDpF6QnFDXmJE4g==",
-          "dev": true
         }
-      }
-    },
-    "verdaccio-htpasswd": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-10.5.2.tgz",
-      "integrity": "sha512-bO5Wm8w07pWswNvwFWjNEoznuUU37CcfblcrU0Ci8c038EgTu2V47uwh4AyZ4PTK6ps9oxHqA7a1b+83sY0OkA==",
-      "dev": true,
-      "requires": {
-        "@verdaccio/file-locking": "10.3.0",
-        "apache-md5": "1.1.8",
-        "bcryptjs": "2.4.3",
-        "http-errors": "2.0.0",
-        "unix-crypt-td-js": "1.1.4"
       }
     },
     "verror": {
@@ -33460,6 +33835,19 @@
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -33627,18 +34015,18 @@
       "requires": {}
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ran the following:

```
npm install
npm audit fix
npm test
```

In general, `npm audit fix` will identify packages with security updates that can be fixed and update them along with dependencies.

In particular, this updated xml2js to `0.5.0`, which should resolve [this vulnerability](https://github.com/aws/aws-encryption-sdk-javascript/security/dependabot/46).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

