### PR TITLE
fix(CD): CodeBuild MUST USE a supported Node Version

### DIFF
--- a/codebuild/release/publish.yml
+++ b/codebuild/release/publish.yml
@@ -18,7 +18,7 @@ phases:
       - npm install otplib --no-save
       - npm run build
     runtime-versions:
-      nodejs: 12
+      nodejs: 14
   pre_build:
     commands:
       - git checkout $BRANCH

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - npm ci --unsafe-perm
     runtime-versions:
-      nodejs: 12
+      nodejs: 14
   pre_build:
     commands:
       - git config --global user.name "aws-crypto-tools-ci-bot"


### PR DESCRIPTION
*Issue #, if available:* CodeBuild Builds MUST USE a supported Node Version.

*Description of changes:*
Replace any usage of Node 12 with Node 14 in AWS CodeBuild Builds for publishing to npm.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

