### PR TITLE
docs(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ which caches cryptographic materials provided by another CMM.
 
 ### Keyrings
 
-Keyrings use wrapping keys to to generate, encrypt, and decrypt data keys.
+Keyrings use wrapping keys to generate, encrypt, and decrypt data keys.
 The keyring that you use determines the source of the unique data keys that protect each message,
 and the wrapping keys that encrypt that data key.
 An example of a keyring is the `KmsKeyringNode`.


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "to to" to "to" (removing redundancy) in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.