### PR TITLE
chore(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ which caches cryptographic materials provided by another CMM.
 
 ### Keyrings
 
-Keyrings use wrapping keys to to generate, encrypt, and decrypt data keys.
+Keyrings use wrapping keys to generate, encrypt, and decrypt data keys.
 The keyring that you use determines the source of the unique data keys that protect each message,
 and the wrapping keys that encrypt that data key.
 An example of a keyring is the `KmsKeyringNode`.


### PR DESCRIPTION
*Issue #, if available:*
This Pull Request fixes a typographical error in the README.md file.

*Description of changes:*
 - Corrected "to to" to "to" in the README.md file.

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

