### PR TITLE
fix: Add CVE-2023-46809 option to integration node

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,9 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': false }],
     // This rule fights with Prettier and no-semi
     '@typescript-eslint/no-extra-semi': 'off',
+    // Added in later versions of @typescript-eslint
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
   },
   // This is a good rule,
   // but in many tests,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   CI:
     strategy:
       matrix:
-          node: [16, 18.3.0, 20.4.0]
+          node: [16, 18.x, 20.x, 22.x, latest]
       fail-fast: false
     runs-on: codebuild-AWS-ESDK-JS-Release-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-5.0-large
     permissions:

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -13,19 +13,20 @@ import {
 const cli = yargs
   .command('decrypt', 'verify decrypt vectors', (y) =>
     y
-  .option('vectorFile', {
-      alias: 'v',
-      describe: 'a vector zip file from aws-encryption-sdk-test-vectors',
-      demandOption: true,
-      type: 'string',
-    })
-    .option('CVE-2023-46809', {
-      alias: 'C',
-      describe: 'Attempt RSA_PKCS1_OAEP_PADDING decrypt vectors, requires node process started with --security-revert=CVE-2023-46809',
-      default: false,
-      demandOption: false,
-      type: 'boolean',
-    })
+      .option('vectorFile', {
+        alias: 'v',
+        describe: 'a vector zip file from aws-encryption-sdk-test-vectors',
+        demandOption: true,
+        type: 'string',
+      })
+      .option('CVE-2023-46809', {
+        alias: 'C',
+        describe:
+          'Attempt RSA_PKCS1_OAEP_PADDING decrypt vectors, requires node process started with --security-revert=CVE-2023-46809',
+        default: false,
+        demandOption: false,
+        type: 'boolean',
+      })
   )
   .command('encrypt', 'verify encrypt manifest', (y) =>
     y
@@ -87,7 +88,7 @@ const cli = yargs
     _: [command],
     tolerateFailures,
     testName,
-    ['CVE-2023-46809']:CVE202346809,
+    ['CVE-2023-46809']: CVE202346809,
     concurrency,
   } = await argv
   /* I set the result to 1 so that if I fall through the exit condition is a failure */

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -12,11 +12,19 @@ import {
 
 const cli = yargs
   .command('decrypt', 'verify decrypt vectors', (y) =>
-    y.option('vectorFile', {
+    y
+  .option('vectorFile', {
       alias: 'v',
       describe: 'a vector zip file from aws-encryption-sdk-test-vectors',
       demandOption: true,
       type: 'string',
+    })
+    .option('CVE-2023-46809', {
+      alias: 'C',
+      describe: 'Attempt RSA_PKCS1_OAEP_PADDING decrypt vectors, requires node process started with --security-revert=CVE-2023-46809',
+      default: false,
+      demandOption: false,
+      type: 'boolean',
     })
   )
   .command('encrypt', 'verify encrypt manifest', (y) =>
@@ -79,6 +87,7 @@ const cli = yargs
     _: [command],
     tolerateFailures,
     testName,
+    ['CVE-2023-46809']:CVE202346809,
     concurrency,
   } = await argv
   /* I set the result to 1 so that if I fall through the exit condition is a failure */
@@ -89,6 +98,7 @@ const cli = yargs
       vectorFile,
       tolerateFailures,
       testName,
+      !!CVE202346809,
       concurrency
     )
   } else if (command === 'encrypt') {

--- a/modules/integration-node/src/integration_tests.ts
+++ b/modules/integration-node/src/integration_tests.ts
@@ -177,7 +177,7 @@ export async function integrationDecryptTestVectors(
     }
 
     if (
-      !CVE202346809 && 
+      !CVE202346809 &&
       test.keysInfo.some(
         ([info, _]) =>
           info.type == 'raw' && info['padding-algorithm'] == 'pkcs1'

--- a/modules/integration-node/src/integration_tests.ts
+++ b/modules/integration-node/src/integration_tests.ts
@@ -162,6 +162,7 @@ export async function integrationDecryptTestVectors(
   vectorFile: string,
   tolerateFailures = 0,
   testName?: string,
+  CVE202346809?: boolean,
   concurrency = 1
 ): Promise<number> {
   const tests = await parseIntegrationTestVectorsToTestVectorIterator(
@@ -174,6 +175,17 @@ export async function integrationDecryptTestVectors(
     if (testName) {
       if (test.name !== testName) return true
     }
+
+    if (
+      !CVE202346809 && 
+      test.keysInfo.some(
+        ([info, _]) =>
+          info.type == 'raw' && info['padding-algorithm'] == 'pkcs1'
+      )
+    ) {
+      return true
+    }
+
     return handleTestResults(
       await testDecryptVector(test),
       notSupportedDecryptMessages

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "integration-browser-encrypt": "npm run build; integration-browser encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle --karma -c cpu",
     "browser-integration": "run-s integration-browser-*",
     "integration-node-decrypt": "npm run build; integration-node decrypt -v $npm_package_config_localTestVectors -c cpu",
+    "integration-node-decrypt-legacy": "node --security-revert=CVE-2023-46809 ./modules/integration-node/build/main/src/cli.js decrypt -v $npm_package_config_localTestVectors -c cpu --CVE-2023-46809",
     "integration-node-encrypt": "npm run build; integration-node encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle -c cpu",
     "node-integration": "run-s integration-node-*",
     "integration": "run-s integration-*",

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -8,14 +8,18 @@ const compilerOptions = Object.assign({
 })
 
 module.exports = function (wallaby) {
+  var path = require('path');
+  process.env.NODE_PATH += path.delimiter + path.join(wallaby.localProjectDir, 'core', 'node_modules');
+
   return {
     files: [
       'modules/**/src/**/*.ts',
       'modules/**/fixtures.ts',
-      '!modules/**/test/**/*.test.ts',
-      '!modules/**/node_modules/**',
-      '!modules/**/build/**',
-      '!modules/*-+(browser|backend)/**/*.ts'
+      { pattern: 'modules/**/test/**/*.test.ts', ignore: true},
+      { pattern: 'modules/**/node_modules/**', ignore: true},
+      { pattern: 'modules/**/build/**', ignore: true},
+      { pattern: 'modules/*-browser/**/*.ts', ignore: true},
+      { pattern: 'modules/*-backend/**/*.ts', ignore: true},
     ],
     tests: [
       'modules/**/test/**/*test.ts',
@@ -32,26 +36,5 @@ module.exports = function (wallaby) {
     },
     env: { type: 'node' },
     debug: true,
-    setup: w => {
-      const { projectCacheDir } = w
-      const path = require('path')
-      const { Module } = require('module')
-      const fs = require('fs')
-      if (!Module._originalRequire) {
-        const modulePrototype = Module.prototype
-        Module._originalRequire = modulePrototype.require
-        modulePrototype.require = function (filePath) {
-          if (!filePath.startsWith('@aws-crypto')) {
-            return Module._originalRequire.call(this, filePath)
-          }
-          const [, _module] = filePath.split('/')
-          const _filePath = path.join(projectCacheDir, 'modules', _module, 'src', 'index.js')
-          if (!fs.existsSync(_filePath)) {
-            return Module._originalRequire.call(this, filePath)
-          }
-          return Module._originalRequire.call(this, _filePath)
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Adding a CVE-2023-46809 to skip
RSA_PKCS1_OAEP_PADDING test vectors.

Adding a CI target to start node
with --security-revert=CVE-2023-46809
and attempt RSA_PKCS1_OAEP_PADDING test vectors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

