### PR TITLE
chore: Fix credentials.expiration

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -127,6 +127,8 @@ function createCredentialPreprocessor() {
     // This will affect the generated (ES5) JS
     const regionCode = `var defaultRegion = '${region}';`
     const credentialsCode = `var credentials = ${JSON.stringify(credentials)};`
+    // See: https://github.com/aws/aws-sdk-js-v3/issues/5890
+    const expirationNeedsToBeDate = `credentials.expiration = new Date(credentials.expiration);`
     const isBrowser = `var isBrowser = true;`
     const contents = content.split('\n')
     let idx = -1
@@ -137,7 +139,7 @@ function createCredentialPreprocessor() {
         break
       }
     }
-    contents.splice(idx + 1, 0, regionCode, credentialsCode, isBrowser)
+    contents.splice(idx + 1, 0, regionCode, credentialsCode, expirationNeedsToBeDate, isBrowser)
     done(contents.join('\n'))
   }
 }


### PR DESCRIPTION
In the SDK credentials.expiration
now needs to be a `Date` object.

See: https://github.com/aws/aws-sdk-js-v3/issues/5890

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

