### PR TITLE
chore: Fix credentials.expiration

### DIFF
--- a/modules/integration-browser/karma.conf.js
+++ b/modules/integration-browser/karma.conf.js
@@ -3,6 +3,8 @@
 
 // Karma configuration
 const { readFileSync } = require('fs')
+const credentialsPromise =
+  require('@aws-sdk/credential-provider-node').defaultProvider()()
 const webpack = require('webpack')
 
 module.exports = function (config) {
@@ -66,8 +68,10 @@ module.exports = function (config) {
       },
     },
     plugins: [
+      {
+        'preprocessor:credentials': ['factory', createCredentialPreprocessor],
+      },
       'karma-parallel',
-      '@aws-sdk/karma-credential-loader',
       'karma-webpack',
       'karma-json-fixtures-preprocessor',
       'karma-chrome-launcher',
@@ -98,4 +102,31 @@ module.exports = function (config) {
       executors: concurrency,
     },
   })
+}
+
+function createCredentialPreprocessor() {
+  return async function (content, file, done) {
+    // strip the extension from the file since it won't match the preprocessor pattern
+    const fileName = file.originalPath
+    // add region and credentials to each file
+    const region = process.env.AWS_SMOKE_TEST_REGION || ''
+    const credentials = await credentialsPromise
+    // This will affect the generated (ES5) JS
+    const regionCode = `var defaultRegion = '${region}';`
+    const credentialsCode = `var credentials = ${JSON.stringify(credentials)};`
+    // See: https://github.com/aws/aws-sdk-js-v3/issues/5890
+    const expirationNeedsToBeDate = `credentials.expiration = new Date(credentials.expiration);`
+    const isBrowser = `var isBrowser = true;`
+    const contents = content.split('\n')
+    let idx = -1
+    for (let i = 0; i < contents.length; i++) {
+      const line = contents[i]
+      if (line.indexOf(fileName) !== -1) {
+        idx = i
+        break
+      }
+    }
+    contents.splice(idx + 1, 0, regionCode, credentialsCode, expirationNeedsToBeDate, isBrowser)
+    done(contents.join('\n'))
+  }
 }

--- a/modules/integration-browser/package.json
+++ b/modules/integration-browser/package.json
@@ -20,7 +20,6 @@
     "@aws-crypto/client-browser": "file:../client-browser",
     "@aws-crypto/integration-vectors": "file:../integration-vectors",
     "@aws-sdk/credential-provider-node": "^3.362.0",
-    "@aws-sdk/karma-credential-loader": "^3.38.0",
     "@aws-sdk/util-base64-browser": "^3.209.0",
     "@aws-sdk/util-utf8-browser": "^3.23.0",
     "@trust/keyto": "^1.0.1",

--- a/modules/material-management-browser/package.json
+++ b/modules/material-management-browser/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/serialize": "file:../serialize",
     "@aws-crypto/web-crypto-backend": "file:../web-crypto-backend",
     "@aws-sdk/util-base64": "^3.374.0",
+    "@aws-sdk/util-base64-browser": "^3.209.0",
     "tslib": "^2.2.0"
   },
   "sideEffects": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
       },
       "devDependencies": {
         "@aws-sdk/credential-provider-node": "^3.362.0",
-        "@aws-sdk/karma-credential-loader": "^3.38.0",
         "@aws-sdk/util-base64": "^3.374.0",
         "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
         "@types/bn.js": "^5.1.0",
@@ -391,7 +390,6 @@
         "@aws-crypto/client-browser": "file:../client-browser",
         "@aws-crypto/integration-vectors": "file:../integration-vectors",
         "@aws-sdk/credential-provider-node": "^3.362.0",
-        "@aws-sdk/karma-credential-loader": "^3.38.0",
         "@aws-sdk/util-base64-browser": "^3.209.0",
         "@aws-sdk/util-utf8-browser": "^3.23.0",
         "@trust/keyto": "^1.0.1",
@@ -415,13 +413,6 @@
       },
       "bin": {
         "integration-browser": "build/main/src/cli.js"
-      }
-    },
-    "modules/integration-browser/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.209.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.1"
       }
     },
     "modules/integration-browser/node_modules/yargs": {
@@ -553,6 +544,7 @@
         "@aws-crypto/serialize": "file:../serialize",
         "@aws-crypto/web-crypto-backend": "file:../web-crypto-backend",
         "@aws-sdk/util-base64": "^3.374.0",
+        "@aws-sdk/util-base64-browser": "^3.209.0",
         "tslib": "^2.2.0"
       }
     },
@@ -744,21 +736,6 @@
     "node_modules/@aws-crypto/hkdf-node": {
       "resolved": "modules/hkdf-node",
       "link": true
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@aws-crypto/integration-browser": {
       "resolved": "modules/integration-browser",
@@ -959,28 +936,6 @@
     "node_modules/@aws-crypto/web-crypto-backend": {
       "resolved": "modules/web-crypto-backend",
       "link": true
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
-      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.614.0",
@@ -1187,30 +1142,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
-      "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-config-provider": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/core": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.614.0.tgz",
@@ -1262,31 +1193,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
-      "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
@@ -1389,431 +1295,6 @@
         "@aws-sdk/client-sts": "^3.609.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
-      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
-      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
-      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
-      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/karma-credential-loader/-/karma-credential-loader-3.40.0.tgz",
-      "integrity": "sha512-p5t5nruHBWMc5PmxLtg8Tmvdvl7ehTRaCi0Hw0QD30l/r3IC8ryUa/eLZguf5hz+lBEMjdOaRmaElzAnFOKRkA==",
-      "deprecated": "Package @aws-sdk/karma-credential-loader has been deprecated.",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sts": "file:../../clients/client-sts",
-        "@aws-sdk/credential-provider-node": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.110.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/client-sso": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.40.0.tgz",
-      "integrity": "sha512-eFQ4yFg8RlPaldv/ja2K3pUUyXauGbo4GJPlbPKYoquwW785au8qECKSl3iqBmUklj6WmdW1rmtlQk2OUcyYSw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/client-sts": {
-      "resolved": "node_modules/clients/client-sts",
-      "link": true
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
-      "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.40.0.tgz",
-      "integrity": "sha512-lyTlgItJ+wPWIkcnkpmZTG+ApCwZBDjLzCPzhFOG1vT1wb0pF3KyJGmjWaW9C6s84rvWwGv1bY3/KBo92KtcjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.40.0",
-        "@aws-sdk/credential-provider-web-identity": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.40.0.tgz",
-      "integrity": "sha512-TANFmUqZwXd2ytA4Ji8IJDC8g42EnogjeIX+ypea/sImY5L7sQpd/sxQlcpIOJlr/6cGL3VhLGh2EGHXEJQEYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.40.0",
-        "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.40.0",
-        "@aws-sdk/credential-provider-web-identity": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
-      "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.40.0.tgz",
-      "integrity": "sha512-8XOz1cDsRvmb6UyLKersi+kLx2Bo4nXpsLZDbTuobEqMwtzIIZKW3C8n8icKpiqq1xhJ6hyT80on+HJ8ykrFKA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.40.0.tgz",
-      "integrity": "sha512-A1KT6Ft3k5B6bU2I2jXS4fSoWbWftEysrxT3zyuzhMbsstsHBJ/J9mEsQ4lgZyr6DXEqn7HD3MbdEoaBN2b3sg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
-      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
-      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
-      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
-      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/karma-credential-loader/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
-      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
-      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
@@ -1858,74 +1339,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
-      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/service-error-classification": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
-      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
-      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.614.0.tgz",
@@ -1940,144 +1353,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
-      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
-      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
-      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
-      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
-      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
-      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
@@ -2095,75 +1370,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
-      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
-      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-hex-encoding": "3.37.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.40.0.tgz",
-      "integrity": "sha512-6x6uvmfhFpkCiT1O/SsFWRyyqs3ZHMB1hVypn9XfT1/XSrfVLhcbBtnX1/UGPkQvA1GJGo5Pkxv3odQfUw7rUg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
@@ -2198,26 +1404,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
-      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-base64": {
       "version": "3.374.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.374.0.tgz",
@@ -2233,25 +1419,13 @@
       }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.37.0.tgz",
-      "integrity": "sha512-o4s/rHVm5k8eC/T7grJQINyYA/mKfDmEWKMA9wk5iBroXlI2rUm7x649TBk5hzoddufk/mffEeNz/1wM7yTmlg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.209.0.tgz",
+      "integrity": "sha512-GY+BDw6YVLEiuJr7BRaJ8giFPsby8nLrEFKjuXmnrFEvVatyjD3yvdj3jJUxOSkrZDMO1ZDVP9iLRLdQLObI3Q==",
+      "deprecated": "The package @aws-sdk/util-base64-browser has been renamed to @aws-sdk/util-base64. Please install the renamed package.",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.37.0.tgz",
-      "integrity": "sha512-1UPxly1GPrGZtlIWvbNCDIAund4Oyp8cFi9neA43TeNACvrmEQu/nG01pDbOoo0ENoVSVJrNAVBeqKEpqjH2GA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-base64/node_modules/@smithy/is-array-buffer": {
@@ -2292,65 +1466,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
-      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
-      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
-      "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
-      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-credentials": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.37.0.tgz",
-      "integrity": "sha512-zcLhSZDKgBLhUjSU5HoQpuQiP3v8oE86NmV/tiZVPEaO6YVULEAB2Cfj1hpM/b/JXWzjSHfT06KXT7QUODKS+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -2366,18 +1481,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
-      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.568.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -2388,18 +1491,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
-      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
@@ -2444,19 +1535,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
-      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8445,7 +7523,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/clients/client-sts": {},
     "node_modules/clipanion": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   ],
   "devDependencies": {
     "@aws-sdk/credential-provider-node": "^3.362.0",
-    "@aws-sdk/karma-credential-loader": "^3.38.0",
     "@aws-sdk/util-base64": "^3.374.0",
     "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "@types/bn.js": "^5.1.0",


### PR DESCRIPTION
In the SDK credentials.expiration
now needs to be a `Date` object.

This also removes `@aws-sdk/karma-credential-loader`

See: https://github.com/aws/aws-sdk-js-v3/issues/5890

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

