### PR TITLE
feat: integration-node can produce decrypt manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ package.json.decrypt
 /modules/kms-keyring-browser/src/version.ts
 /modules/kms-keyring-node/src/version.ts
 /modules/branch-keystore-node/src/version.ts
+/modules/integration-node/src/version.ts

--- a/modules/integration-node/package.json
+++ b/modules/integration-node/package.json
@@ -24,7 +24,8 @@
     "got": "^11.8.0",
     "stream-to-promise": "^3.0.0",
     "tslib": "^2.3.0",
-    "yargs": "^17.0.1"
+    "yargs": "^17.0.1",
+    "yazl": "^3.3.1"
   },
   "sideEffects": false,
   "main": "./build/main/src/index.js",

--- a/modules/integration-node/package.json
+++ b/modules/integration-node/package.json
@@ -2,6 +2,8 @@
   "name": "@aws-crypto/integration-node",
   "version": "4.1.0",
   "scripts": {
+    "prepublishOnly": "npm run generate-version.ts; npm run build",
+    "generate-version.ts": "npx genversion --es6  src/version.ts",
     "build": "tsc -b tsconfig.json",
     "lint": "run-s lint-*",
     "lint-eslint": "eslint src/*.ts test/*.ts",

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -109,12 +109,13 @@ const cli = yargs
       concurrency
     )
   } else if (command === 'encrypt') {
-    const { manifestFile, keyFile, decryptOracle, decryptManifest } = argv as unknown as {
-      manifestFile: string
-      keyFile: string
-      decryptOracle?: string,
-      decryptManifest?: string,
-    }
+    const { manifestFile, keyFile, decryptOracle, decryptManifest } =
+      argv as unknown as {
+        manifestFile: string
+        keyFile: string
+        decryptOracle?: string
+        decryptManifest?: string
+      }
     result = await integrationEncryptTestVectors(
       manifestFile,
       keyFile,

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -47,7 +47,13 @@ const cli = yargs
       .option('decryptOracle', {
         alias: 'o',
         describe: 'a url to the decrypt oracle',
-        demandOption: true,
+        demandOption: false,
+        type: 'string',
+      })
+      .option('decryptManifest', {
+        alias: 'd',
+        describe: 'a file path for to create a decrypt manifest zip file',
+        demandOption: false,
         type: 'string',
       })
   )
@@ -103,15 +109,17 @@ const cli = yargs
       concurrency
     )
   } else if (command === 'encrypt') {
-    const { manifestFile, keyFile, decryptOracle } = argv as unknown as {
+    const { manifestFile, keyFile, decryptOracle, decryptManifest } = argv as unknown as {
       manifestFile: string
       keyFile: string
-      decryptOracle: string
+      decryptOracle?: string,
+      decryptManifest?: string,
     }
     result = await integrationEncryptTestVectors(
       manifestFile,
       keyFile,
       decryptOracle,
+      decryptManifest,
       tolerateFailures,
       testName,
       concurrency

--- a/modules/integration-node/src/constants.ts
+++ b/modules/integration-node/src/constants.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const KEYS_MANIFEST_NAME_FILENAME = 'keys.json'
+export const MANIFEST_NAME_FILENAME = 'manifest.json'
+export const DECRYPT_MANIFEST_TYPE = 'awses-decrypt'
+export const DECRYPT_MANIFEST_CLIENT_NAME = 'aws/aws-encryption-sdk-javascript'
+export const MANIFEST_URI_PREFIX = 'file://'
+export const MANIFEST_PLAINTEXT_PATH = 'plaintexts/'
+export const MANIFEST_CIPHERTEXT_PATH = 'ciphertexts/'

--- a/modules/integration-node/src/get_encrypt_test_iterator.ts
+++ b/modules/integration-node/src/get_encrypt_test_iterator.ts
@@ -14,28 +14,42 @@ import {
 import { URL } from 'url'
 import { readFileSync } from 'fs'
 import got from 'got'
+import { ZipFile } from 'yazl'
 
 export async function getEncryptTestVectorIterator(
   manifestFile: string,
-  keyFile: string
+  keyFile: string,
+  manifestZip?: ZipFile,
 ) {
   const [manifest, keys]: [EncryptManifestList, KeyList] = await Promise.all([
     getParsedJSON(manifestFile),
     getParsedJSON(keyFile),
   ])
 
-  return _getEncryptTestVectorIterator(manifest, keys)
+  return _getEncryptTestVectorIterator(manifest, keys, manifestZip)
 }
 
 /* Just a simple more testable function */
 export function _getEncryptTestVectorIterator(
   { tests, plaintexts }: EncryptManifestList,
-  { keys }: KeyList
+  keysManifest: KeyList,
+  manifestZip?: ZipFile,
 ) {
+
+  if (manifestZip) {
+    // We assume that the keys manifest given for encrypt
+    // has all the keys required for decrypt.
+    manifestZip.addBuffer(Buffer.from(JSON.stringify(keysManifest)), `keys.json`)
+  }
+  const { keys } = keysManifest
   const plaintextBytes: { [name: string]: Buffer } = {}
 
   Object.keys(plaintexts).forEach((name) => {
     plaintextBytes[name] = randomBytes(plaintexts[name])
+
+    if (manifestZip) {
+      manifestZip.addBuffer(plaintextBytes[name], `plaintexts/${name}`)
+    }
   })
 
   return (function* nextTest(): IterableIterator<EncryptTestVectorInfo> {
@@ -60,6 +74,7 @@ export function _getEncryptTestVectorIterator(
         name,
         keysInfo,
         plainTextData: plaintextBytes[plaintext],
+        plaintextName: plaintext,
         encryptOp: { suiteId, frameLength, encryptionContext },
       }
     }
@@ -70,6 +85,7 @@ export interface EncryptTestVectorInfo {
   name: string
   keysInfo: KeyInfoTuple[]
   plainTextData: Buffer
+  plaintextName: string
   encryptOp: {
     suiteId: AlgorithmSuiteIdentifier
     frameLength: number

--- a/modules/integration-node/src/get_encrypt_test_iterator.ts
+++ b/modules/integration-node/src/get_encrypt_test_iterator.ts
@@ -15,6 +15,10 @@ import { URL } from 'url'
 import { readFileSync } from 'fs'
 import got from 'got'
 import { ZipFile } from 'yazl'
+import {
+  KEYS_MANIFEST_NAME_FILENAME,
+  MANIFEST_PLAINTEXT_PATH,
+} from './constants'
 
 export async function getEncryptTestVectorIterator(
   manifestFile: string,
@@ -40,7 +44,7 @@ export function _getEncryptTestVectorIterator(
     // has all the keys required for decrypt.
     manifestZip.addBuffer(
       Buffer.from(JSON.stringify(keysManifest)),
-      `keys.json`
+      `${KEYS_MANIFEST_NAME_FILENAME}`
     )
   }
   const { keys } = keysManifest
@@ -50,7 +54,10 @@ export function _getEncryptTestVectorIterator(
     plaintextBytes[name] = randomBytes(plaintexts[name])
 
     if (manifestZip) {
-      manifestZip.addBuffer(plaintextBytes[name], `plaintexts/${name}`)
+      manifestZip.addBuffer(
+        plaintextBytes[name],
+        `${MANIFEST_PLAINTEXT_PATH}${name}`
+      )
     }
   })
 

--- a/modules/integration-node/src/get_encrypt_test_iterator.ts
+++ b/modules/integration-node/src/get_encrypt_test_iterator.ts
@@ -19,7 +19,7 @@ import { ZipFile } from 'yazl'
 export async function getEncryptTestVectorIterator(
   manifestFile: string,
   keyFile: string,
-  manifestZip?: ZipFile,
+  manifestZip?: ZipFile
 ) {
   const [manifest, keys]: [EncryptManifestList, KeyList] = await Promise.all([
     getParsedJSON(manifestFile),
@@ -33,13 +33,15 @@ export async function getEncryptTestVectorIterator(
 export function _getEncryptTestVectorIterator(
   { tests, plaintexts }: EncryptManifestList,
   keysManifest: KeyList,
-  manifestZip?: ZipFile,
+  manifestZip?: ZipFile
 ) {
-
   if (manifestZip) {
     // We assume that the keys manifest given for encrypt
     // has all the keys required for decrypt.
-    manifestZip.addBuffer(Buffer.from(JSON.stringify(keysManifest)), `keys.json`)
+    manifestZip.addBuffer(
+      Buffer.from(JSON.stringify(keysManifest)),
+      `keys.json`
+    )
   }
   const { keys } = keysManifest
   const plaintextBytes: { [name: string]: Buffer } = {}

--- a/modules/integration-node/src/integration_tests.ts
+++ b/modules/integration-node/src/integration_tests.ts
@@ -183,9 +183,9 @@ function composeEncryptResults(
       },
       manifestZip: manifest.manifestZip,
     }
-  } else if (!!decryptOracle) {
+  } else if (decryptOracle) {
     return decryptOracleEncryptResults(decryptOracle)
-  } else if (!!decryptManifest) {
+  } else if (decryptManifest) {
     return decryptionManifestEncryptResults(decryptManifest)
   }
   needs(false, 'unsupported')
@@ -199,7 +199,9 @@ function decryptOracleEncryptResults(
     handleEncryptResult,
     // There is nothing to do when the oracle is done
     // since nothing is saved.
-    done: () => {},
+    done: () => {
+      return null
+    },
   }
 
   async function handleEncryptResult(
@@ -412,8 +414,10 @@ async function parallelTests<
     if (!value && done) {
       // We are done enqueueing work,
       // but we need to wait until all that work is done
-      Promise.all([...queue]).then(() => _resolve(failureCount))
-      return 
+      Promise.all([...queue])
+        .then(() => _resolve(failureCount))
+        .catch(console.log)
+      return
     }
     /* I need to define the work to be enqueue
      * and a way to dequeue this work when complete.

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,7 +468,8 @@
         "got": "^11.8.0",
         "stream-to-promise": "^3.0.0",
         "tslib": "^2.3.0",
-        "yargs": "^17.0.1"
+        "yargs": "^17.0.1",
+        "yazl": "^3.3.1"
       },
       "bin": {
         "integration-node": "build/main/src/cli.js"
@@ -21443,6 +21444,24 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
+    },
+    "node_modules/yazl/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/from2": "^2.3.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
+        "@types/yazl": "^2.4.6",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
         "aws-sdk": "^2.1409.0",
@@ -5476,6 +5477,16 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yazl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.6.tgz",
+      "integrity": "sha512-/ifFjQtcKaoZOjl5NNCQRR0fAKafB3Foxd7J/WvFPTMea46zekapcR30uzkwIkKAAuq5T6d0dkwz754RFH27hg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/from2": "^2.3.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
+    "@types/yazl": "^2.4.6",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "aws-sdk": "^2.1409.0",


### PR DESCRIPTION
From a given encrypt manifest,
integration-node now takes
`—-decryptManifest` | `-d`

This will create a ziped decrypt manifest
that can be consumed by decrypt.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

