### PR TITLE
chore(CI): Restrict `end-of-stream` version for browser test vectors

### DIFF
--- a/modules/integration-browser/package.json
+++ b/modules/integration-browser/package.json
@@ -27,6 +27,7 @@
     "@types/stream-to-promise": "^2.2.0",
     "@types/yargs": "^17.0.1",
     "buffer": "^6.0.3",
+    "end-of-stream": "<=1.4.4",
     "got": "^11.8.0",
     "jasmine-core": "^3.5.0",
     "karma": "^6.3.4",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "buffer": "^6.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "end-of-stream": "<=1.4.4",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^9.0.0",
     "from2": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "buffer": "^6.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "end-of-stream": "<=1.4.4",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^9.0.0",
     "from2": "^2.3.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`end-of-stream` introduced an unguarded reference to `process` in its patch version update from `1.4.4` to `1.4.5`. ([link](https://github.com/mafintosh/end-of-stream/compare/v1.4.4...v1.4.5))
`process` isn't broadly supported in browser environments, so this change effectively dropped support for browser for many consumers despite being a patch release.

This change: Limit support for `end-of-stream` to max `1.4.4` in our browser integration testing module.

(We don't use this package elsewhere in our browser modules.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

